### PR TITLE
Codex API Support: Feature Parity & UI Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 cli
 cli-dev
+openclaw/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common commands
+
+```bash
+# Install dependencies
+bun install
+
+# Standard build (./cli)
+bun run build
+
+# Dev build (./cli-dev)
+bun run build:dev
+
+# Dev build with all experimental features (./cli-dev)
+bun run build:dev:full
+
+# Compiled build (./dist/cli)
+bun run compile
+
+# Run from source without compiling
+bun run dev
+```
+
+Run the built binary with `./cli` or `./cli-dev`. Set `ANTHROPIC_API_KEY` in the environment or use OAuth via `./cli /login`.
+
+## High-level architecture
+
+- **Entry point/UI loop**: src/entrypoints/cli.tsx bootstraps the CLI, with the main interactive UI in src/screens/REPL.tsx (Ink/React).
+- **Command/tool registries**: src/commands.ts registers slash commands; src/tools.ts registers tool implementations. Implementations live in src/commands/ and src/tools/.
+- **LLM query pipeline**: src/QueryEngine.ts coordinates message flow, tool use, and model invocation.
+- **Core subsystems**:
+  - src/services/: API clients, OAuth/MCP integration, analytics stubs
+  - src/state/: app state store
+  - src/hooks/: React hooks used by UI/flows
+  - src/components/: terminal UI components (Ink)
+  - src/skills/: skill system
+  - src/plugins/: plugin system
+  - src/bridge/: IDE bridge
+  - src/voice/: voice input
+  - src/tasks/: background task management
+
+## Build system
+
+- scripts/build.ts is the build script and feature-flag bundler. Feature flags are set via build arguments (e.g., `--feature=ULTRAPLAN`) or presets like `--feature-set=dev-full` (see README for details).

--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,24 @@
+# Codex API Support: Feature Parity & UI Overhaul
+
+## Summary
+This pull request introduces full feature parity and explicit UI support for the OpenAI Codex backend (`chatgpt.com/backend-api/codex/responses`). The codebase is now entirely backend-agnostic and smoothly transitions between Anthropic Claude and OpenAI Codex schemas based on current authentication, without losing features like reasoning animations, token billing, or multi-modal visual inputs.
+
+## Key Changes
+
+### 1. Codex API Gateway Adapter (`codex-fetch-adapter.ts`)
+- **Native Vision Translation**: Anthropic `base64` image schemas now map precisely to the Codex expected `input_image` payloads.
+- **Strict Payload Mapping**: Refactored the internal mapping logic to translate `msg.content` items precisely into `input_text`, sidestepping OpenAI's strict `v1/responses` validation rules (`Invalid value: 'text'`).
+- **Tool Logic Fixes**: Properly routed `tool_result` items into top-level `function_call_output` objects to guarantee that local CLI tool executions (File Reads, Bash loops) cleanly feed back into Codex logic without throwing "No tool output found" errors.
+- **Cache Stripping**: Cleanly stripped Anthropic-only `cache_control` annotations from tool bindings and prompts prior to transmission so the Codex API doesn't reject malformed JSON.
+
+### 2. Deep UI & Routing Integration
+- **Model Cleanups (`model.ts`)**: Updated `getPublicModelDisplayName` and `getClaudeAiUserDefaultModelDescription` to recognize Codex GPT strings. Models like `gpt-5.1-codex-max` now beautifully map to `Codex 5.1 Max` in the CLI visual outputs instead of passing the raw proxy IDs.
+- **Default Reroutes**: Made `getDefaultMainLoopModelSetting` aware of `isCodexSubscriber()`, automatically defaulting to `gpt-5.2-codex` instead of `sonnet46`.
+- **Billing Visuals (`logoV2Utils.ts`)**: Refactored `formatModelAndBilling` logic to render `Codex API Billing` proudly inside the terminal header when authenticated.
+
+### 3. Reasoning & Metrics Support
+- **Thinking Animations**: `codex-fetch-adapter` now intentionally intercepts the proprietary `response.reasoning.delta` SSE frames emitted by `codex-max` models. It wraps them into Anthropic `<thinking>` events, ensuring the standard CLI "Thinking..." spinner continues to function flawlessly for OpenAI reasoning.
+- **Token Accuracy**: Bound logic to track `response.completed` completion events, fetching `usage.input_tokens` and `output_tokens`. These are injected natively into the final `message_stop` token handler, meaning Codex queries correctly trigger the terminal's Token/Price tracker summary logic.
+
+### 4. Git Housekeeping
+- Configured `.gitignore` to securely and durably exclude the `openclaw/` gateway directory from staging commits.

--- a/src/cli/handlers/auth.ts
+++ b/src/cli/handlers/auth.ts
@@ -27,6 +27,7 @@ import {
   getOauthAccountInfo,
   getSubscriptionType,
   isUsing3PServices,
+  saveCodexOAuthTokens,
   saveOAuthTokensIfNeeded,
   validateForceLoginOrg,
 } from '../../utils/auth.js'
@@ -42,6 +43,16 @@ import {
   buildAccountProperties,
   buildAPIProviderProperties,
 } from '../../utils/status.js'
+
+/**
+ * Returns true if the token carries any Anthropic-issued scope (user:* or org:*).
+ * Codex tokens use OpenID Connect scopes (openid, profile, email, offline_access)
+ * which are not Anthropic scopes, so this returns false for them.
+ */
+function hasAnyAnthropicScope(scopes: string[] | undefined): boolean {
+  if (!scopes?.length) return false
+  return scopes.some((s) => s.startsWith('user:') || s.startsWith('org:'))
+}
 
 /**
  * Shared post-token-acquisition logic. Saves tokens, fetches profile/roles,
@@ -96,7 +107,7 @@ export async function installOAuthTokens(tokens: OAuthTokens): Promise<void> {
     await fetchAndStoreClaudeCodeFirstTokenDate().catch(err =>
       logForDebugging(String(err), { level: 'error' }),
     )
-  } else {
+  } else if (hasAnyAnthropicScope(tokens.scopes)) {
     // API key creation is critical for Console users — let it throw.
     const apiKey = await createAndStoreApiKey(tokens.accessToken)
     if (!apiKey) {
@@ -104,6 +115,16 @@ export async function installOAuthTokens(tokens: OAuthTokens): Promise<void> {
         'Unable to create API key. The server accepted the request but did not return a key.',
       )
     }
+  } else {
+    // Third-party provider (e.g. OpenAI Codex) — tokens carry no Anthropic
+    // scopes. Skip Anthropic API key creation entirely and store the tokens
+    // in their own dedicated config slot.
+    saveCodexOAuthTokens({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken ?? '',
+      expiresAt: tokens.expiresAt ?? Date.now() + 3600_000,
+      accountId: (tokens.tokenAccount?.uuid ?? ''),
+    })
   }
 
   await clearAuthRelatedCaches()

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -9,8 +9,9 @@ import { Box, Link, Text } from '../ink.js';
 import { useKeybinding } from '../keybindings/useKeybinding.js';
 import { getSSLErrorHint } from '../services/api/errorUtils.js';
 import { sendNotification } from '../services/notifier.js';
+import { runCodexOAuthFlow } from '../services/oauth/codex-client.js';
 import { OAuthService } from '../services/oauth/index.js';
-import { getOauthAccountInfo, validateForceLoginOrg } from '../utils/auth.js';
+import { getOauthAccountInfo, saveCodexOAuthTokens, validateForceLoginOrg } from '../utils/auth.js';
 import { logError } from '../utils/log.js';
 import { getSettings_DEPRECATED } from '../utils/settings/settings.js';
 import { Select } from './CustomSelect/select.js';
@@ -84,6 +85,7 @@ export function ConsoleOAuthFlow({
     // Use Claude AI auth for setup-token mode to support user:inference scope
     return mode === 'setup-token' || forceLoginMethod === 'claudeai';
   });
+  const [loginWithCodex, setLoginWithCodex] = useState(false);
   // After a few seconds we suggest the user to copy/paste url if the
   // browser did not open automatically. In this flow we expect the user to
   // copy the code from the browser and paste it in the terminal
@@ -235,7 +237,7 @@ export function ConsoleOAuthFlow({
         await installOAuthTokens(result);
         const orgResult = await validateForceLoginOrg();
         if (!orgResult.valid) {
-          throw new Error(orgResult.message);
+          throw new Error('message' in orgResult ? (orgResult as any).message : 'Invalid organization');
         }
         setOAuthStatus({
           state: 'success'
@@ -261,16 +263,46 @@ export function ConsoleOAuthFlow({
       });
     }
   }, [oauthService, setShowPastePrompt, loginWithClaudeAi, mode, orgUUID]);
+
+  // Codex-specific OAuth flow — completely separate from the Anthropic OAuthService
+  const startCodexOAuth = useCallback(async () => {
+    try {
+      logEvent('tengu_oauth_codex_flow_start', {});
+      const codexTokens = await runCodexOAuthFlow(async (url) => {
+        setOAuthStatus({ state: 'waiting_for_login', url });
+        setTimeout(setShowPastePrompt, 3000, true);
+      });
+      // Save directly via saveCodexOAuthTokens (bypasses installOAuthTokens Anthropic path)
+      saveCodexOAuthTokens(codexTokens);
+      logEvent('tengu_oauth_codex_success', {});
+      setOAuthStatus({ state: 'success' });
+      void sendNotification({ message: 'Codex login successful', notificationType: 'auth_success' }, terminal);
+    } catch (err) {
+      const msg = (err as Error).message;
+      logEvent('tengu_oauth_codex_error', {
+        error: msg as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      });
+      setOAuthStatus({ state: 'error', message: msg, toRetry: { state: 'idle' } });
+    }
+  }, [setShowPastePrompt, terminal]);
+
   const pendingOAuthStartRef = useRef(false);
   useEffect(() => {
     if (oauthStatus.state === 'ready_to_start' && !pendingOAuthStartRef.current) {
       pendingOAuthStartRef.current = true;
-      process.nextTick((startOAuth_0: () => Promise<void>, pendingOAuthStartRef_0: React.MutableRefObject<boolean>) => {
-        void startOAuth_0();
-        pendingOAuthStartRef_0.current = false;
-      }, startOAuth, pendingOAuthStartRef);
+      if (loginWithCodex) {
+        process.nextTick((startCodexOAuth_0: () => Promise<void>, pendingOAuthStartRef_0: React.MutableRefObject<boolean>) => {
+          void startCodexOAuth_0();
+          pendingOAuthStartRef_0.current = false;
+        }, startCodexOAuth, pendingOAuthStartRef);
+      } else {
+        process.nextTick((startOAuth_0: () => Promise<void>, pendingOAuthStartRef_0: React.MutableRefObject<boolean>) => {
+          void startOAuth_0();
+          pendingOAuthStartRef_0.current = false;
+        }, startOAuth, pendingOAuthStartRef);
+      }
     }
-  }, [oauthStatus.state, startOAuth]);
+  }, [oauthStatus.state, startOAuth, startCodexOAuth, loginWithCodex]);
 
   // Auto-exit for setup-token mode
   useEffect(() => {
@@ -325,7 +357,7 @@ export function ConsoleOAuthFlow({
             </Box>
           </Box>}
       <Box paddingLeft={1} flexDirection="column" gap={1}>
-        <OAuthStatusMessage oauthStatus={oauthStatus} mode={mode} startingMessage={startingMessage} forcedMethodMessage={forcedMethodMessage} showPastePrompt={showPastePrompt} pastedCode={pastedCode} setPastedCode={setPastedCode} cursorOffset={cursorOffset} setCursorOffset={setCursorOffset} textInputColumns={textInputColumns} handleSubmitCode={handleSubmitCode} setOAuthStatus={setOAuthStatus} setLoginWithClaudeAi={setLoginWithClaudeAi} />
+        <OAuthStatusMessage oauthStatus={oauthStatus} mode={mode} startingMessage={startingMessage} forcedMethodMessage={forcedMethodMessage} showPastePrompt={showPastePrompt} pastedCode={pastedCode} setPastedCode={setPastedCode} cursorOffset={cursorOffset} setCursorOffset={setCursorOffset} textInputColumns={textInputColumns} handleSubmitCode={handleSubmitCode} setOAuthStatus={setOAuthStatus} setLoginWithClaudeAi={setLoginWithClaudeAi} setLoginWithCodex={setLoginWithCodex} />
       </Box>
     </Box>;
 }
@@ -343,9 +375,10 @@ type OAuthStatusMessageProps = {
   handleSubmitCode: (value: string, url: string) => void;
   setOAuthStatus: (status: OAuthStatus) => void;
   setLoginWithClaudeAi: (value: boolean) => void;
+  setLoginWithCodex: (value: boolean) => void;
 };
 function OAuthStatusMessage(t0) {
-  const $ = _c(51);
+  const $ = _c(52);
   const {
     oauthStatus,
     mode,
@@ -359,7 +392,8 @@ function OAuthStatusMessage(t0) {
     textInputColumns,
     handleSubmitCode,
     setOAuthStatus,
-    setLoginWithClaudeAi
+    setLoginWithClaudeAi,
+    setLoginWithCodex
   } = t0;
   switch (oauthStatus.state) {
     case "idle":
@@ -405,20 +439,29 @@ function OAuthStatusMessage(t0) {
           t6 = [t4, t5, {
             label: <Text>3rd-party platform ·{" "}<Text dimColor={true}>Amazon Bedrock, Microsoft Foundry, or Vertex AI</Text>{"\n"}</Text>,
             value: "platform"
+          }, {
+            label: <Text>OpenAI Codex account ·{" "}<Text dimColor={true}>ChatGPT Plus/Pro subscription</Text>{"\n"}</Text>,
+            value: "codex"
           }];
           $[5] = t6;
         } else {
           t6 = $[5];
         }
         let t7;
-        if ($[6] !== setLoginWithClaudeAi || $[7] !== setOAuthStatus) {
+        if ($[6] !== setLoginWithClaudeAi || $[7] !== setOAuthStatus || $[8] !== setLoginWithCodex) {
           t7 = <Box><Select options={t6} onChange={value_0 => {
               if (value_0 === "platform") {
                 logEvent("tengu_oauth_platform_selected", {});
                 setOAuthStatus({
                   state: "platform_setup"
                 });
+              } else if (value_0 === "codex") {
+                logEvent("tengu_oauth_codex_selected", {});
+                setLoginWithCodex(true);
+                setLoginWithClaudeAi(false);
+                setOAuthStatus({ state: "ready_to_start" });
               } else {
+                setLoginWithCodex(false);
                 setOAuthStatus({
                   state: "ready_to_start"
                 });
@@ -433,192 +476,193 @@ function OAuthStatusMessage(t0) {
             }} /></Box>;
           $[6] = setLoginWithClaudeAi;
           $[7] = setOAuthStatus;
-          $[8] = t7;
+          $[8] = setLoginWithCodex;
+          $[9] = t7;
         } else {
-          t7 = $[8];
+          t7 = $[9];
         }
         let t8;
-        if ($[9] !== t2 || $[10] !== t7) {
+        if ($[10] !== t2 || $[11] !== t7) {
           t8 = <Box flexDirection="column" gap={1} marginTop={1}>{t2}{t3}{t7}</Box>;
-          $[9] = t2;
-          $[10] = t7;
-          $[11] = t8;
+          $[10] = t2;
+          $[11] = t7;
+          $[12] = t8;
         } else {
-          t8 = $[11];
+          t8 = $[12];
         }
         return t8;
       }
     case "platform_setup":
       {
         let t1;
-        if ($[12] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[13] === Symbol.for("react.memo_cache_sentinel")) {
           t1 = <Text bold={true}>Using 3rd-party platforms</Text>;
-          $[12] = t1;
+          $[13] = t1;
         } else {
-          t1 = $[12];
+          t1 = $[13];
         }
         let t2;
         let t3;
-        if ($[13] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[14] === Symbol.for("react.memo_cache_sentinel")) {
           t2 = <Text>Claude Code supports Amazon Bedrock, Microsoft Foundry, and Vertex AI. Set the required environment variables, then restart Claude Code.</Text>;
           t3 = <Text>If you are part of an enterprise organization, contact your administrator for setup instructions.</Text>;
-          $[13] = t2;
-          $[14] = t3;
+          $[14] = t2;
+          $[15] = t3;
         } else {
-          t2 = $[13];
-          t3 = $[14];
+          t2 = $[14];
+          t3 = $[15];
         }
         let t4;
-        if ($[15] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[16] === Symbol.for("react.memo_cache_sentinel")) {
           t4 = <Text bold={true}>Documentation:</Text>;
-          $[15] = t4;
+          $[16] = t4;
         } else {
-          t4 = $[15];
+          t4 = $[16];
         }
         let t5;
-        if ($[16] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[17] === Symbol.for("react.memo_cache_sentinel")) {
           t5 = <Text>· Amazon Bedrock:{" "}<Link url="https://code.claude.com/docs/en/amazon-bedrock">https://code.claude.com/docs/en/amazon-bedrock</Link></Text>;
-          $[16] = t5;
+          $[17] = t5;
         } else {
-          t5 = $[16];
+          t5 = $[17];
         }
         let t6;
-        if ($[17] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[18] === Symbol.for("react.memo_cache_sentinel")) {
           t6 = <Text>· Microsoft Foundry:{" "}<Link url="https://code.claude.com/docs/en/microsoft-foundry">https://code.claude.com/docs/en/microsoft-foundry</Link></Text>;
-          $[17] = t6;
+          $[18] = t6;
         } else {
-          t6 = $[17];
+          t6 = $[18];
         }
         let t7;
-        if ($[18] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[19] === Symbol.for("react.memo_cache_sentinel")) {
           t7 = <Box flexDirection="column" marginTop={1}>{t4}{t5}{t6}<Text>· Vertex AI:{" "}<Link url="https://code.claude.com/docs/en/google-vertex-ai">https://code.claude.com/docs/en/google-vertex-ai</Link></Text></Box>;
-          $[18] = t7;
+          $[19] = t7;
         } else {
-          t7 = $[18];
+          t7 = $[19];
         }
         let t8;
-        if ($[19] === Symbol.for("react.memo_cache_sentinel")) {
+        if ($[20] === Symbol.for("react.memo_cache_sentinel")) {
           t8 = <Box flexDirection="column" gap={1} marginTop={1}>{t1}<Box flexDirection="column" gap={1}>{t2}{t3}{t7}<Box marginTop={1}><Text dimColor={true}>Press <Text bold={true}>Enter</Text> to go back to login options.</Text></Box></Box></Box>;
-          $[19] = t8;
+          $[20] = t8;
         } else {
-          t8 = $[19];
+          t8 = $[20];
         }
         return t8;
       }
     case "waiting_for_login":
       {
         let t1;
-        if ($[20] !== forcedMethodMessage) {
+        if ($[21] !== forcedMethodMessage) {
           t1 = forcedMethodMessage && <Box><Text dimColor={true}>{forcedMethodMessage}</Text></Box>;
-          $[20] = forcedMethodMessage;
-          $[21] = t1;
+          $[21] = forcedMethodMessage;
+          $[22] = t1;
         } else {
-          t1 = $[21];
+          t1 = $[22];
         }
         let t2;
-        if ($[22] !== showPastePrompt) {
+        if ($[23] !== showPastePrompt) {
           t2 = !showPastePrompt && <Box><Spinner /><Text>Opening browser to sign in…</Text></Box>;
-          $[22] = showPastePrompt;
-          $[23] = t2;
+          $[23] = showPastePrompt;
+          $[24] = t2;
         } else {
-          t2 = $[23];
+          t2 = $[24];
         }
         let t3;
-        if ($[24] !== cursorOffset || $[25] !== handleSubmitCode || $[26] !== oauthStatus.url || $[27] !== pastedCode || $[28] !== setCursorOffset || $[29] !== setPastedCode || $[30] !== showPastePrompt || $[31] !== textInputColumns) {
+        if ($[25] !== cursorOffset || $[26] !== handleSubmitCode || $[27] !== oauthStatus.url || $[28] !== pastedCode || $[29] !== setCursorOffset || $[30] !== setPastedCode || $[31] !== showPastePrompt || $[32] !== textInputColumns) {
           t3 = showPastePrompt && <Box><Text>{PASTE_HERE_MSG}</Text><TextInput value={pastedCode} onChange={setPastedCode} onSubmit={value => handleSubmitCode(value, oauthStatus.url)} cursorOffset={cursorOffset} onChangeCursorOffset={setCursorOffset} columns={textInputColumns} mask="*" /></Box>;
-          $[24] = cursorOffset;
-          $[25] = handleSubmitCode;
-          $[26] = oauthStatus.url;
-          $[27] = pastedCode;
-          $[28] = setCursorOffset;
-          $[29] = setPastedCode;
-          $[30] = showPastePrompt;
-          $[31] = textInputColumns;
-          $[32] = t3;
+          $[25] = cursorOffset;
+          $[26] = handleSubmitCode;
+          $[27] = oauthStatus.url;
+          $[28] = pastedCode;
+          $[29] = setCursorOffset;
+          $[30] = setPastedCode;
+          $[31] = showPastePrompt;
+          $[32] = textInputColumns;
+          $[33] = t3;
         } else {
-          t3 = $[32];
+          t3 = $[33];
         }
         let t4;
-        if ($[33] !== t1 || $[34] !== t2 || $[35] !== t3) {
+        if ($[34] !== t1 || $[35] !== t2 || $[36] !== t3) {
           t4 = <Box flexDirection="column" gap={1}>{t1}{t2}{t3}</Box>;
-          $[33] = t1;
-          $[34] = t2;
-          $[35] = t3;
-          $[36] = t4;
+          $[34] = t1;
+          $[35] = t2;
+          $[36] = t3;
+          $[37] = t4;
         } else {
-          t4 = $[36];
+          t4 = $[37];
         }
         return t4;
       }
     case "creating_api_key":
       {
         let t1;
-        if ($[37] === Symbol.for("react.memo_cache_sentinel")) {
-          t1 = <Box flexDirection="column" gap={1}><Box><Spinner /><Text>Creating API key for Claude Code…</Text></Box></Box>;
-          $[37] = t1;
-        } else {
-          t1 = $[37];
-        }
-        return t1;
-      }
-    case "about_to_retry":
-      {
-        let t1;
         if ($[38] === Symbol.for("react.memo_cache_sentinel")) {
-          t1 = <Box flexDirection="column" gap={1}><Text color="permission">Retrying…</Text></Box>;
+          t1 = <Box flexDirection="column" gap={1}><Box><Spinner /><Text>Creating API key for Claude Code…</Text></Box></Box>;
           $[38] = t1;
         } else {
           t1 = $[38];
         }
         return t1;
       }
+    case "about_to_retry":
+      {
+        let t1;
+        if ($[39] === Symbol.for("react.memo_cache_sentinel")) {
+          t1 = <Box flexDirection="column" gap={1}><Text color="permission">Retrying…</Text></Box>;
+          $[39] = t1;
+        } else {
+          t1 = $[39];
+        }
+        return t1;
+      }
     case "success":
       {
         let t1;
-        if ($[39] !== mode || $[40] !== oauthStatus.token) {
+        if ($[40] !== mode || $[41] !== oauthStatus.token) {
           t1 = mode === "setup-token" && oauthStatus.token ? null : <>{getOauthAccountInfo()?.emailAddress ? <Text dimColor={true}>Logged in as{" "}<Text>{getOauthAccountInfo()?.emailAddress}</Text></Text> : null}<Text color="success">Login successful. Press <Text bold={true}>Enter</Text> to continue…</Text></>;
-          $[39] = mode;
-          $[40] = oauthStatus.token;
-          $[41] = t1;
+          $[40] = mode;
+          $[41] = oauthStatus.token;
+          $[42] = t1;
         } else {
-          t1 = $[41];
+          t1 = $[42];
         }
         let t2;
-        if ($[42] !== t1) {
+        if ($[43] !== t1) {
           t2 = <Box flexDirection="column">{t1}</Box>;
-          $[42] = t1;
-          $[43] = t2;
+          $[43] = t1;
+          $[44] = t2;
         } else {
-          t2 = $[43];
+          t2 = $[44];
         }
         return t2;
       }
     case "error":
       {
         let t1;
-        if ($[44] !== oauthStatus.message) {
+        if ($[45] !== oauthStatus.message) {
           t1 = <Text color="error">OAuth error: {oauthStatus.message}</Text>;
-          $[44] = oauthStatus.message;
-          $[45] = t1;
+          $[45] = oauthStatus.message;
+          $[46] = t1;
         } else {
-          t1 = $[45];
+          t1 = $[46];
         }
         let t2;
-        if ($[46] !== oauthStatus.toRetry) {
+        if ($[47] !== oauthStatus.toRetry) {
           t2 = oauthStatus.toRetry && <Box marginTop={1}><Text color="permission">Press <Text bold={true}>Enter</Text> to retry.</Text></Box>;
-          $[46] = oauthStatus.toRetry;
-          $[47] = t2;
+          $[47] = oauthStatus.toRetry;
+          $[48] = t2;
         } else {
-          t2 = $[47];
+          t2 = $[48];
         }
         let t3;
-        if ($[48] !== t1 || $[49] !== t2) {
+        if ($[49] !== t1 || $[50] !== t2) {
           t3 = <Box flexDirection="column" gap={1}>{t1}{t2}</Box>;
-          $[48] = t1;
-          $[49] = t2;
-          $[50] = t3;
+          $[49] = t1;
+          $[50] = t2;
+          $[51] = t3;
         } else {
-          t3 = $[50];
+          t3 = $[51];
         }
         return t3;
       }

--- a/src/constants/codex-oauth.ts
+++ b/src/constants/codex-oauth.ts
@@ -1,0 +1,44 @@
+/**
+ * OpenAI Codex OAuth constants.
+ *
+ * These values are extracted from the @mariozechner/pi-ai package used by the
+ * openclaw project. The Codex OAuth flow uses OpenAI's own auth server at
+ * auth.openai.com and is completely separate from Anthropic's OAuth flow.
+ *
+ * References:
+ * - Client ID: app_EMoamEEZ73f0CkXaXp7hrann
+ * - Authorize URL: https://auth.openai.com/oauth/authorize
+ * - Token URL: https://auth.openai.com/oauth/token
+ * - Redirect URI: http://localhost:1455/auth/callback (fixed port per OpenAI's registration)
+ */
+
+/** The registered OAuth client ID for Codex CLI tools */
+export const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+
+/** OpenAI's authorization endpoint */
+export const CODEX_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize'
+
+/** OpenAI's token exchange / refresh endpoint */
+export const CODEX_TOKEN_URL = 'https://auth.openai.com/oauth/token'
+
+/**
+ * The redirect URI registered for the Codex OAuth app.
+ * OpenAI requires a fixed port (1455) — unlike Anthropic which uses OS-assigned ports.
+ */
+export const CODEX_REDIRECT_URI = 'http://localhost:1455/auth/callback'
+
+/** Space-separated OAuth scopes requested from OpenAI */
+export const CODEX_SCOPES = 'openid profile email offline_access'
+
+/**
+ * JWT claim namespace where OpenAI places the chatgpt_account_id.
+ * The account ID is extracted from the access token JWT:
+ *   payload["https://api.openai.com/auth"].chatgpt_account_id
+ */
+export const CODEX_JWT_AUTH_CLAIM = 'https://api.openai.com/auth'
+
+/**
+ * Provider identifier used in config storage to distinguish Codex credentials
+ * from Anthropic credentials.
+ */
+export const CODEX_PROVIDER_ID = 'openai-codex' as const

--- a/src/constants/oauth.ts
+++ b/src/constants/oauth.ts
@@ -35,6 +35,10 @@ export const CLAUDE_AI_PROFILE_SCOPE = 'user:profile' as const
 const CONSOLE_SCOPE = 'org:create_api_key' as const
 export const OAUTH_BETA_HEADER = 'oauth-2025-04-20' as const
 
+// OpenAI OAuth scopes
+export const OPENAI_API_SCOPE = 'api' as const
+export const OPENAI_CODEX_SCOPE = 'codex' as const
+
 // Console OAuth scopes - for API key creation via Console
 export const CONSOLE_OAUTH_SCOPES = [
   CONSOLE_SCOPE,
@@ -48,6 +52,12 @@ export const CLAUDE_AI_OAUTH_SCOPES = [
   'user:sessions:claude_code',
   'user:mcp_servers',
   'user:file_upload',
+] as const
+
+// OpenAI OAuth scopes - for OpenAI Codex users
+export const OPENAI_OAUTH_SCOPES = [
+  OPENAI_API_SCOPE,
+  OPENAI_CODEX_SCOPE,
 ] as const
 
 // All OAuth scopes - union of all scopes used in Claude CLI
@@ -68,11 +78,16 @@ type OauthConfig = {
    * /settings/connectors, and other claude.ai web pages.
    */
   CLAUDE_AI_ORIGIN: string
+  // OpenAI OAuth URLs
+  OPENAI_AUTHORIZE_URL: string
+  OPENAI_TOKEN_URL: string
+  OPENAI_CLIENT_ID: string
   TOKEN_URL: string
   API_KEY_URL: string
   ROLES_URL: string
   CONSOLE_SUCCESS_URL: string
   CLAUDEAI_SUCCESS_URL: string
+  OPENAI_SUCCESS_URL: string
   MANUAL_REDIRECT_URL: string
   CLIENT_ID: string
   OAUTH_FILE_SUFFIX: string
@@ -88,6 +103,10 @@ const PROD_OAUTH_CONFIG = {
   // visits for attribution. 307s to claude.ai/oauth/authorize in two hops.
   CLAUDE_AI_AUTHORIZE_URL: 'https://claude.com/cai/oauth/authorize',
   CLAUDE_AI_ORIGIN: 'https://claude.ai',
+  // OpenAI OAuth URLs
+  OPENAI_AUTHORIZE_URL: 'https://openai.com/oauth/authorize',
+  OPENAI_TOKEN_URL: 'https://openai.com/oauth/token',
+  OPENAI_CLIENT_ID: 'claude-code-client',
   TOKEN_URL: 'https://platform.claude.com/v1/oauth/token',
   API_KEY_URL: 'https://api.anthropic.com/api/oauth/claude_cli/create_api_key',
   ROLES_URL: 'https://api.anthropic.com/api/oauth/claude_cli/roles',
@@ -95,6 +114,8 @@ const PROD_OAUTH_CONFIG = {
     'https://platform.claude.com/buy_credits?returnUrl=/oauth/code/success%3Fapp%3Dclaude-code',
   CLAUDEAI_SUCCESS_URL:
     'https://platform.claude.com/oauth/code/success?app=claude-code',
+  OPENAI_SUCCESS_URL:
+    'https://openai.com/oauth/success?app=claude-code',
   MANUAL_REDIRECT_URL: 'https://platform.claude.com/oauth/code/callback',
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   // No suffix for production config
@@ -124,6 +145,10 @@ const STAGING_OAUTH_CONFIG =
         CLAUDE_AI_AUTHORIZE_URL:
           'https://claude-ai.staging.ant.dev/oauth/authorize',
         CLAUDE_AI_ORIGIN: 'https://claude-ai.staging.ant.dev',
+        // OpenAI OAuth URLs (staging)
+        OPENAI_AUTHORIZE_URL: 'https://openai.com/oauth/authorize',
+        OPENAI_TOKEN_URL: 'https://openai.com/oauth/token',
+        OPENAI_CLIENT_ID: 'claude-code-staging-client',
         TOKEN_URL: 'https://platform.staging.ant.dev/v1/oauth/token',
         API_KEY_URL:
           'https://api-staging.anthropic.com/api/oauth/claude_cli/create_api_key',
@@ -133,6 +158,8 @@ const STAGING_OAUTH_CONFIG =
           'https://platform.staging.ant.dev/buy_credits?returnUrl=/oauth/code/success%3Fapp%3Dclaude-code',
         CLAUDEAI_SUCCESS_URL:
           'https://platform.staging.ant.dev/oauth/code/success?app=claude-code',
+        OPENAI_SUCCESS_URL:
+          'https://openai.com/oauth/success?app=claude-code-staging',
         MANUAL_REDIRECT_URL:
           'https://platform.staging.ant.dev/oauth/code/callback',
         CLIENT_ID: '22422756-60c9-4084-8eb7-27705fd5cf9a',
@@ -160,11 +187,16 @@ function getLocalOauthConfig(): OauthConfig {
     CONSOLE_AUTHORIZE_URL: `${consoleBase}/oauth/authorize`,
     CLAUDE_AI_AUTHORIZE_URL: `${apps}/oauth/authorize`,
     CLAUDE_AI_ORIGIN: apps,
+    // OpenAI OAuth URLs (local dev)
+    OPENAI_AUTHORIZE_URL: 'https://openai.com/oauth/authorize',
+    OPENAI_TOKEN_URL: 'https://openai.com/oauth/token',
+    OPENAI_CLIENT_ID: 'claude-code-local-client',
     TOKEN_URL: `${api}/v1/oauth/token`,
     API_KEY_URL: `${api}/api/oauth/claude_cli/create_api_key`,
     ROLES_URL: `${api}/api/oauth/claude_cli/roles`,
     CONSOLE_SUCCESS_URL: `${consoleBase}/buy_credits?returnUrl=/oauth/code/success%3Fapp%3Dclaude-code`,
     CLAUDEAI_SUCCESS_URL: `${consoleBase}/oauth/code/success?app=claude-code`,
+    OPENAI_SUCCESS_URL: 'https://openai.com/oauth/success?app=claude-code-local',
     MANUAL_REDIRECT_URL: `${consoleBase}/oauth/code/callback`,
     CLIENT_ID: '22422756-60c9-4084-8eb7-27705fd5cf9a',
     OAUTH_FILE_SUFFIX: '-local-oauth',

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -1,5 +1,15 @@
 import { feature } from 'bun:bundle';
 
+// Define MACRO global for development (normally injected by bun build --define)
+if (typeof MACRO === 'undefined') {
+  (globalThis as any).MACRO = {
+    VERSION: '2.1.87-dev',
+    BUILD_TIME: new Date().toISOString(),
+    PACKAGE_URL: 'claude-code-source-snapshot',
+    FEEDBACK_CHANNEL: 'github',
+  };
+}
+
 // Bugfix for corepack auto-pinning, which adds yarnpkg to peoples' package.jsons
 // eslint-disable-next-line custom-rules/no-top-level-side-effects
 process.env.COREPACK_ENABLE_AUTO_PIN = '0';

--- a/src/hooks/useApiKeyVerification.ts
+++ b/src/hooks/useApiKeyVerification.ts
@@ -6,6 +6,7 @@ import {
   getApiKeyFromApiKeyHelper,
   isAnthropicAuthEnabled,
   isClaudeAISubscriber,
+  isCodexSubscriber,
 } from '../utils/auth.js'
 
 export type VerificationStatus =
@@ -23,7 +24,7 @@ export type ApiKeyVerificationResult = {
 
 export function useApiKeyVerification(): ApiKeyVerificationResult {
   const [status, setStatus] = useState<VerificationStatus>(() => {
-    if (!isAnthropicAuthEnabled() || isClaudeAISubscriber()) {
+    if (!isAnthropicAuthEnabled() || isClaudeAISubscriber() || isCodexSubscriber()) {
       return 'valid'
     }
     // Use skipRetrievingKeyFromApiKeyHelper to avoid executing apiKeyHelper
@@ -41,7 +42,7 @@ export function useApiKeyVerification(): ApiKeyVerificationResult {
   const [error, setError] = useState<Error | null>(null)
 
   const verify = useCallback(async (): Promise<void> => {
-    if (!isAnthropicAuthEnabled() || isClaudeAISubscriber()) {
+    if (!isAnthropicAuthEnabled() || isClaudeAISubscriber() || isCodexSubscriber()) {
       setStatus('valid')
       return
     }

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -6,7 +6,9 @@ import {
   getAnthropicApiKey,
   getApiKeyFromApiKeyHelper,
   getClaudeAIOAuthTokens,
+  getCodexOAuthTokens,
   isClaudeAISubscriber,
+  isCodexSubscriber,
   refreshAndGetAwsCredentials,
   refreshGcpCredentialsIfNeeded,
 } from 'src/utils/auth.js'
@@ -28,6 +30,7 @@ import {
   getVertexRegionForModel,
   isEnvTruthy,
 } from '../../utils/envUtils.js'
+import { createCodexFetch } from './codex-fetch-adapter.js'
 
 /**
  * Environment variables for different client types:
@@ -295,6 +298,21 @@ export async function getAnthropicClient({
     }
     // we have always been lying about the return type - this doesn't support batching or models
     return new AnthropicVertex(vertexArgs) as unknown as Anthropic
+  }
+
+  // ── Codex (OpenAI) provider via fetch adapter ─────────────────────
+  if (isCodexSubscriber()) {
+    const codexTokens = getCodexOAuthTokens()
+    if (codexTokens?.accessToken) {
+      const codexFetch = createCodexFetch(codexTokens.accessToken)
+      const clientConfig: ConstructorParameters<typeof Anthropic>[0] = {
+        apiKey: 'codex-placeholder', // SDK requires a key but the fetch adapter handles auth
+        ...ARGS,
+        fetch: codexFetch as unknown as typeof globalThis.fetch,
+        ...(isDebugToStdErr() && { logger: createStderrLogger() }),
+      }
+      return new Anthropic(clientConfig)
+    }
   }
 
   // Determine authentication method based on available tokens

--- a/src/services/api/codex-fetch-adapter.ts
+++ b/src/services/api/codex-fetch-adapter.ts
@@ -29,6 +29,11 @@ export const CODEX_MODELS = [
 
 export const DEFAULT_CODEX_MODEL = 'gpt-5.2-codex'
 
+/**
+ * Maps Claude model names to corresponding Codex model names.
+ * @param claudeModel - The Claude model name to map
+ * @returns The corresponding Codex model ID
+ */
 export function mapClaudeModelToCodex(claudeModel: string | null): string {
   if (!claudeModel) return DEFAULT_CODEX_MODEL
   if (isCodexModel(claudeModel)) return claudeModel
@@ -39,6 +44,11 @@ export function mapClaudeModelToCodex(claudeModel: string | null): string {
   return DEFAULT_CODEX_MODEL
 }
 
+/**
+ * Checks if a given model string is a valid Codex model.
+ * @param model - The model string to check
+ * @returns True if the model is a Codex model, false otherwise
+ */
 export function isCodexModel(model: string): boolean {
   return CODEX_MODELS.some(m => m.id === model)
 }
@@ -47,6 +57,12 @@ export function isCodexModel(model: string): boolean {
 
 const JWT_CLAIM_PATH = 'https://api.openai.com/auth'
 
+/**
+ * Extracts the account ID from a Codex JWT token.
+ * @param token - The JWT token to extract the account ID from
+ * @returns The account ID
+ * @throws Error if the token is invalid or account ID cannot be extracted
+ */
 function extractAccountId(token: string): string {
   try {
     const parts = token.split('.')
@@ -86,6 +102,11 @@ interface AnthropicTool {
 
 // ── Tool translation: Anthropic → Codex ─────────────────────────────
 
+/**
+ * Translates Anthropic tool definitions to Codex format.
+ * @param anthropicTools - Array of Anthropic tool definitions
+ * @returns Array of Codex-compatible tool objects
+ */
 function translateTools(anthropicTools: AnthropicTool[]): Array<Record<string, unknown>> {
   return anthropicTools.map(tool => ({
     type: 'function',
@@ -98,6 +119,12 @@ function translateTools(anthropicTools: AnthropicTool[]): Array<Record<string, u
 
 // ── Message translation: Anthropic → Codex input ────────────────────
 
+/**
+ * Translates Anthropic message format to Codex input format.
+ * Handles text content, tool results, and image attachments.
+ * @param anthropicMessages - Array of messages in Anthropic format
+ * @returns Array of Codex-compatible input objects
+ */
 function translateMessages(
   anthropicMessages: AnthropicMessage[],
 ): Array<Record<string, unknown>> {
@@ -187,6 +214,11 @@ function translateMessages(
 
 // ── Full request translation ────────────────────────────────────────
 
+/**
+ * Translates a complete Anthropic API request body to Codex format.
+ * @param anthropicBody - The Anthropic request body to translate
+ * @returns Object containing the translated Codex body and model
+ */
 function translateToCodexBody(anthropicBody: Record<string, unknown>): {
   codexBody: Record<string, unknown>
   codexModel: string
@@ -238,10 +270,23 @@ function translateToCodexBody(anthropicBody: Record<string, unknown>): {
 
 // ── Response translation: Codex SSE → Anthropic SSE ─────────────────
 
+/**
+ * Formats data as Server-Sent Events (SSE) format.
+ * @param event - The event type
+ * @param data - The data payload
+ * @returns Formatted SSE string
+ */
 function formatSSE(event: string, data: string): string {
   return `event: ${event}\ndata: ${data}\n\n`
 }
 
+/**
+ * Translates Codex streaming response to Anthropic format.
+ * Converts Codex SSE events into Anthropic-compatible streaming events.
+ * @param codexResponse - The streaming response from Codex API
+ * @param codexModel - The Codex model used for the request
+ * @returns Transformed Response object with Anthropic-format stream
+ */
 async function translateCodexStreamToAnthropic(
   codexResponse: Response,
   codexModel: string,
@@ -693,6 +738,11 @@ async function translateCodexStreamToAnthropic(
 
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex/responses'
 
+/**
+ * Creates a fetch function that intercepts Anthropic API calls and routes them to Codex.
+ * @param accessToken - The Codex access token for authentication
+ * @returns A fetch function that translates Anthropic requests to Codex format
+ */
 export function createCodexFetch(
   accessToken: string,
 ): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {

--- a/src/services/api/codex-fetch-adapter.ts
+++ b/src/services/api/codex-fetch-adapter.ts
@@ -1,0 +1,762 @@
+/**
+ * Codex Fetch Adapter
+ *
+ * Intercepts fetch calls from the Anthropic SDK and routes them to
+ * ChatGPT's Codex backend API, translating between Anthropic Messages API
+ * format and OpenAI Responses API format.
+ *
+ * Supports:
+ * - Text messages (user/assistant)
+ * - System prompts → instructions
+ * - Tool definitions (Anthropic input_schema → OpenAI parameters)
+ * - Tool use (tool_use → function_call, tool_result → function_call_output)
+ * - Streaming events translation
+ *
+ * Endpoint: https://chatgpt.com/backend-api/codex/responses
+ */
+
+import { getCodexOAuthTokens } from '../../utils/auth.js'
+
+// ── Available Codex models ──────────────────────────────────────────
+export const CODEX_MODELS = [
+  { id: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', description: 'Frontier agentic coding model' },
+  { id: 'gpt-5.1-codex', label: 'GPT-5.1 Codex', description: 'Codex coding model' },
+  { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini', description: 'Fast Codex model' },
+  { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max', description: 'Max Codex model' },
+  { id: 'gpt-5.4', label: 'GPT-5.4', description: 'Latest GPT' },
+  { id: 'gpt-5.2', label: 'GPT-5.2', description: 'GPT-5.2' },
+] as const
+
+export const DEFAULT_CODEX_MODEL = 'gpt-5.2-codex'
+
+export function mapClaudeModelToCodex(claudeModel: string | null): string {
+  if (!claudeModel) return DEFAULT_CODEX_MODEL
+  if (isCodexModel(claudeModel)) return claudeModel
+  const lower = claudeModel.toLowerCase()
+  if (lower.includes('opus')) return 'gpt-5.1-codex-max'
+  if (lower.includes('haiku')) return 'gpt-5.1-codex-mini'
+  if (lower.includes('sonnet')) return 'gpt-5.2-codex'
+  return DEFAULT_CODEX_MODEL
+}
+
+export function isCodexModel(model: string): boolean {
+  return CODEX_MODELS.some(m => m.id === model)
+}
+
+// ── JWT helpers ─────────────────────────────────────────────────────
+
+const JWT_CLAIM_PATH = 'https://api.openai.com/auth'
+
+function extractAccountId(token: string): string {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) throw new Error('Invalid token')
+    const payload = JSON.parse(atob(parts[1]))
+    const accountId = payload?.[JWT_CLAIM_PATH]?.chatgpt_account_id
+    if (!accountId) throw new Error('No account ID in token')
+    return accountId
+  } catch {
+    throw new Error('Failed to extract account ID from Codex token')
+  }
+}
+
+// ── Types ───────────────────────────────────────────────────────────
+
+interface AnthropicContentBlock {
+  type: string
+  text?: string
+  id?: string
+  name?: string
+  input?: Record<string, unknown>
+  tool_use_id?: string
+  content?: string | AnthropicContentBlock[]
+  [key: string]: unknown
+}
+
+interface AnthropicMessage {
+  role: string
+  content: string | AnthropicContentBlock[]
+}
+
+interface AnthropicTool {
+  name: string
+  description?: string
+  input_schema?: Record<string, unknown>
+}
+
+// ── Tool translation: Anthropic → Codex ─────────────────────────────
+
+function translateTools(anthropicTools: AnthropicTool[]): Array<Record<string, unknown>> {
+  return anthropicTools.map(tool => ({
+    type: 'function',
+    name: tool.name,
+    description: tool.description || '',
+    parameters: tool.input_schema || { type: 'object', properties: {} },
+    strict: null,
+  }))
+}
+
+// ── Message translation: Anthropic → Codex input ────────────────────
+
+function translateMessages(
+  anthropicMessages: AnthropicMessage[],
+): Array<Record<string, unknown>> {
+  const codexInput: Array<Record<string, unknown>> = []
+  // Track tool_use IDs to generate call_ids for function_call_output
+  // Anthropic uses tool_use_id, Codex uses call_id
+  let toolCallCounter = 0
+
+  for (const msg of anthropicMessages) {
+    if (typeof msg.content === 'string') {
+      codexInput.push({ role: msg.role, content: msg.content })
+      continue
+    }
+
+    if (!Array.isArray(msg.content)) continue
+
+    if (msg.role === 'user') {
+      const contentArr: Array<Record<string, unknown>> = []
+      for (const block of msg.content) {
+        if (block.type === 'tool_result') {
+          const callId = block.tool_use_id || `call_${toolCallCounter++}`
+          let outputText = ''
+          if (typeof block.content === 'string') {
+            outputText = block.content
+          } else if (Array.isArray(block.content)) {
+            outputText = block.content
+              .map(c => {
+                if (c.type === 'text') return c.text
+                if (c.type === 'image') return '[Image data attached]'
+                return ''
+              })
+              .join('\n')
+          }
+          codexInput.push({
+            type: 'function_call_output',
+            call_id: callId,
+            output: outputText || '',
+          })
+        } else if (block.type === 'text' && typeof block.text === 'string') {
+          contentArr.push({ type: 'input_text', text: block.text })
+        } else if (
+          block.type === 'image' &&
+          typeof block.source === 'object' &&
+          block.source !== null &&
+          (block.source as any).type === 'base64'
+        ) {
+          contentArr.push({
+            type: 'input_image',
+            image_url: `data:${(block.source as any).media_type};base64,${(block.source as any).data}`,
+          })
+        }
+      }
+      if (contentArr.length > 0) {
+        if (contentArr.length === 1 && contentArr[0].type === 'input_text') {
+          codexInput.push({ role: 'user', content: contentArr[0].text })
+        } else {
+          codexInput.push({ role: 'user', content: contentArr })
+        }
+      }
+    } else {
+      // Process assistant or tool blocks
+      for (const block of msg.content) {
+        if (block.type === 'text' && typeof block.text === 'string') {
+          if (msg.role === 'assistant') {
+            codexInput.push({
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: block.text, annotations: [] }],
+              status: 'completed',
+            })
+          }
+        } else if (block.type === 'tool_use') {
+          const callId = block.id || `call_${toolCallCounter++}`
+          codexInput.push({
+            type: 'function_call',
+            call_id: callId,
+            name: block.name || '',
+            arguments: JSON.stringify(block.input || {}),
+          })
+        }
+      }
+    }
+  }
+
+  return codexInput
+}
+
+// ── Full request translation ────────────────────────────────────────
+
+function translateToCodexBody(anthropicBody: Record<string, unknown>): {
+  codexBody: Record<string, unknown>
+  codexModel: string
+} {
+  const anthropicMessages = (anthropicBody.messages || []) as AnthropicMessage[]
+  const systemPrompt = anthropicBody.system as
+    | string
+    | Array<{ type: string; text?: string; cache_control?: unknown }>
+    | undefined
+  const claudeModel = anthropicBody.model as string
+  const anthropicTools = (anthropicBody.tools || []) as AnthropicTool[]
+
+  const codexModel = mapClaudeModelToCodex(claudeModel)
+
+  // Build system instructions
+  let instructions = ''
+  if (systemPrompt) {
+    instructions =
+      typeof systemPrompt === 'string'
+        ? systemPrompt
+        : Array.isArray(systemPrompt)
+          ? systemPrompt
+              .filter(b => b.type === 'text' && typeof b.text === 'string')
+              .map(b => b.text!)
+              .join('\n')
+          : ''
+  }
+
+  // Convert messages
+  const input = translateMessages(anthropicMessages)
+
+  const codexBody: Record<string, unknown> = {
+    model: codexModel,
+    store: false,
+    stream: true,
+    instructions,
+    input,
+    tool_choice: 'auto',
+    parallel_tool_calls: true,
+  }
+
+  // Add tools if present
+  if (anthropicTools.length > 0) {
+    codexBody.tools = translateTools(anthropicTools)
+  }
+
+  return { codexBody, codexModel }
+}
+
+// ── Response translation: Codex SSE → Anthropic SSE ─────────────────
+
+function formatSSE(event: string, data: string): string {
+  return `event: ${event}\ndata: ${data}\n\n`
+}
+
+async function translateCodexStreamToAnthropic(
+  codexResponse: Response,
+  codexModel: string,
+): Promise<Response> {
+  const messageId = `msg_codex_${Date.now()}`
+
+  const readable = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder()
+      let contentBlockIndex = 0
+      let outputTokens = 0
+      let inputTokens = 0
+
+      // Emit Anthropic message_start
+      controller.enqueue(
+        encoder.encode(
+          formatSSE(
+            'message_start',
+            JSON.stringify({
+              type: 'message_start',
+              message: {
+                id: messageId,
+                type: 'message',
+                role: 'assistant',
+                content: [],
+                model: codexModel,
+                stop_reason: null,
+                stop_sequence: null,
+                usage: { input_tokens: 0, output_tokens: 0 },
+              },
+            }),
+          ),
+        ),
+      )
+
+      // Emit ping
+      controller.enqueue(
+        encoder.encode(
+          formatSSE('ping', JSON.stringify({ type: 'ping' })),
+        ),
+      )
+
+      // Track state for tool calls
+      let currentTextBlockStarted = false
+      let currentToolCallId = ''
+      let currentToolCallName = ''
+      let currentToolCallArgs = ''
+      let inToolCall = false
+      let hadToolCalls = false
+      let inReasoningBlock = false
+
+      try {
+        const reader = codexResponse.body?.getReader()
+        if (!reader) {
+          emitTextBlock(controller, encoder, contentBlockIndex, 'Error: No response body')
+          finishStream(controller, encoder, outputTokens, inputTokens, false)
+          return
+        }
+
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          for (const line of lines) {
+            const trimmed = line.trim()
+            if (!trimmed) continue
+
+            // Parse "event: xxx" lines
+            if (trimmed.startsWith('event: ')) continue
+
+            if (!trimmed.startsWith('data: ')) continue
+            const dataStr = trimmed.slice(6)
+            if (dataStr === '[DONE]') continue
+
+            let event: Record<string, unknown>
+            try {
+              event = JSON.parse(dataStr)
+            } catch {
+              continue
+            }
+
+            const eventType = event.type as string
+
+            // ── Text output events ──────────────────────────────
+            if (eventType === 'response.output_item.added') {
+              const item = event.item as Record<string, unknown>
+              if (item?.type === 'reasoning') {
+                inReasoningBlock = true
+                controller.enqueue(
+                  encoder.encode(
+                    formatSSE(
+                      'content_block_start',
+                      JSON.stringify({
+                        type: 'content_block_start',
+                        index: contentBlockIndex,
+                        content_block: { type: 'thinking', thinking: '' },
+                      }),
+                    ),
+                  ),
+                )
+              } else if (item?.type === 'message') {
+                // New text message block starting
+                if (inToolCall) {
+                  // Close the previous tool call block
+                  closeToolCallBlock(controller, encoder, contentBlockIndex, currentToolCallId, currentToolCallName, currentToolCallArgs)
+                  contentBlockIndex++
+                  inToolCall = false
+                }
+              } else if (item?.type === 'function_call') {
+                // Close text block if open
+                if (currentTextBlockStarted) {
+                  controller.enqueue(
+                    encoder.encode(
+                      formatSSE('content_block_stop', JSON.stringify({
+                        type: 'content_block_stop',
+                        index: contentBlockIndex,
+                      })),
+                    ),
+                  )
+                  contentBlockIndex++
+                  currentTextBlockStarted = false
+                }
+
+                // Start tool_use block (Anthropic format)
+                currentToolCallId = (item.call_id as string) || `toolu_${Date.now()}`
+                currentToolCallName = (item.name as string) || ''
+                currentToolCallArgs = (item.arguments as string) || ''
+                inToolCall = true
+                hadToolCalls = true
+
+                controller.enqueue(
+                  encoder.encode(
+                    formatSSE('content_block_start', JSON.stringify({
+                      type: 'content_block_start',
+                      index: contentBlockIndex,
+                      content_block: {
+                        type: 'tool_use',
+                        id: currentToolCallId,
+                        name: currentToolCallName,
+                        input: {},
+                      },
+                    })),
+                  ),
+                )
+              }
+            }
+
+            // Text deltas
+            else if (eventType === 'response.output_text.delta') {
+              const text = event.delta as string
+              if (typeof text === 'string' && text.length > 0) {
+                if (!currentTextBlockStarted) {
+                  // Start a new text content block
+                  controller.enqueue(
+                    encoder.encode(
+                      formatSSE('content_block_start', JSON.stringify({
+                        type: 'content_block_start',
+                        index: contentBlockIndex,
+                        content_block: { type: 'text', text: '' },
+                      })),
+                    ),
+                  )
+                  currentTextBlockStarted = true
+                }
+                controller.enqueue(
+                  encoder.encode(
+                    formatSSE('content_block_delta', JSON.stringify({
+                      type: 'content_block_delta',
+                      index: contentBlockIndex,
+                      delta: { type: 'text_delta', text },
+                    })),
+                  ),
+                )
+                outputTokens += 1
+              }
+            }
+            
+            // Reasoning deltas
+            else if (eventType === 'response.reasoning.delta') {
+              const text = event.delta as string
+              if (typeof text === 'string' && text.length > 0) {
+                if (!inReasoningBlock) {
+                  inReasoningBlock = true
+                  controller.enqueue(
+                    encoder.encode(
+                      formatSSE('content_block_start', JSON.stringify({
+                        type: 'content_block_start',
+                        index: contentBlockIndex,
+                        content_block: { type: 'thinking', thinking: '' },
+                      })),
+                    ),
+                  )
+                }
+                controller.enqueue(
+                  encoder.encode(
+                    formatSSE('content_block_delta', JSON.stringify({
+                      type: 'content_block_delta',
+                      index: contentBlockIndex,
+                      delta: { type: 'thinking_delta', thinking: text },
+                    })),
+                  ),
+                )
+                outputTokens += 1 // approximate token counts
+              }
+            }
+
+            // ── Tool call argument deltas ───────────────────────
+            else if (eventType === 'response.function_call_arguments.delta') {
+              const argDelta = event.delta as string
+              if (typeof argDelta === 'string' && inToolCall) {
+                currentToolCallArgs += argDelta
+                controller.enqueue(
+                  encoder.encode(
+                    formatSSE('content_block_delta', JSON.stringify({
+                      type: 'content_block_delta',
+                      index: contentBlockIndex,
+                      delta: {
+                        type: 'input_json_delta',
+                        partial_json: argDelta,
+                      },
+                    })),
+                  ),
+                )
+              }
+            }
+
+            // Tool call arguments complete
+            else if (eventType === 'response.function_call_arguments.done') {
+              if (inToolCall) {
+                currentToolCallArgs = (event.arguments as string) || currentToolCallArgs
+              }
+            }
+
+            // Output item done — close blocks
+            else if (eventType === 'response.output_item.done') {
+              const item = event.item as Record<string, unknown>
+              if (item?.type === 'function_call') {
+                closeToolCallBlock(controller, encoder, contentBlockIndex, currentToolCallId, currentToolCallName, currentToolCallArgs)
+                contentBlockIndex++
+                inToolCall = false
+                currentToolCallArgs = ''
+              } else if (item?.type === 'message') {
+                if (currentTextBlockStarted) {
+                  controller.enqueue(
+                    encoder.encode(
+                      formatSSE('content_block_stop', JSON.stringify({
+                        type: 'content_block_stop',
+                        index: contentBlockIndex,
+                      })),
+                    ),
+                  )
+                  contentBlockIndex++
+                  currentTextBlockStarted = false
+                }
+              } else if (item?.type === 'reasoning') {
+                if (inReasoningBlock) {
+                  controller.enqueue(
+                    encoder.encode(
+                      formatSSE('content_block_stop', JSON.stringify({
+                        type: 'content_block_stop',
+                        index: contentBlockIndex,
+                      })),
+                    ),
+                  )
+                  contentBlockIndex++
+                  inReasoningBlock = false
+                }
+              }
+            }
+
+            // Response completed — extract usage
+            else if (eventType === 'response.completed') {
+              const response = event.response as Record<string, unknown>
+              const usage = response?.usage as Record<string, number> | undefined
+              if (usage) {
+                outputTokens = usage.output_tokens || outputTokens
+                inputTokens = usage.input_tokens || inputTokens
+              }
+            }
+          }
+        }
+      } catch (err) {
+        // If we're in the middle of a text block, emit the error there
+        if (!currentTextBlockStarted) {
+          controller.enqueue(
+            encoder.encode(
+              formatSSE('content_block_start', JSON.stringify({
+                type: 'content_block_start',
+                index: contentBlockIndex,
+                content_block: { type: 'text', text: '' },
+              })),
+            ),
+          )
+          currentTextBlockStarted = true
+        }
+        controller.enqueue(
+          encoder.encode(
+            formatSSE('content_block_delta', JSON.stringify({
+              type: 'content_block_delta',
+              index: contentBlockIndex,
+              delta: { type: 'text_delta', text: `\n\n[Error: ${String(err)}]` },
+            })),
+          ),
+        )
+      }
+
+      // Close any remaining open blocks
+      if (currentTextBlockStarted) {
+        controller.enqueue(
+          encoder.encode(
+            formatSSE('content_block_stop', JSON.stringify({
+              type: 'content_block_stop',
+              index: contentBlockIndex,
+            })),
+          ),
+        )
+      }
+      if (inReasoningBlock) {
+        controller.enqueue(
+          encoder.encode(
+            formatSSE('content_block_stop', JSON.stringify({
+              type: 'content_block_stop',
+              index: contentBlockIndex,
+            })),
+          ),
+        )
+      }
+      if (inToolCall) {
+        closeToolCallBlock(controller, encoder, contentBlockIndex, currentToolCallId, currentToolCallName, currentToolCallArgs)
+      }
+
+      finishStream(controller, encoder, outputTokens, inputTokens, hadToolCalls)
+    },
+  })
+
+  function closeToolCallBlock(
+    controller: ReadableStreamDefaultController,
+    encoder: TextEncoder,
+    index: number,
+    _toolCallId: string,
+    _toolCallName: string,
+    _toolCallArgs: string,
+  ) {
+    controller.enqueue(
+      encoder.encode(
+        formatSSE('content_block_stop', JSON.stringify({
+          type: 'content_block_stop',
+          index,
+        })),
+      ),
+    )
+  }
+
+  function emitTextBlock(
+    controller: ReadableStreamDefaultController,
+    encoder: TextEncoder,
+    index: number,
+    text: string,
+  ) {
+    controller.enqueue(
+      encoder.encode(
+        formatSSE('content_block_start', JSON.stringify({
+          type: 'content_block_start',
+          index,
+          content_block: { type: 'text', text: '' },
+        })),
+      ),
+    )
+    controller.enqueue(
+      encoder.encode(
+        formatSSE('content_block_delta', JSON.stringify({
+          type: 'content_block_delta',
+          index,
+          delta: { type: 'text_delta', text },
+        })),
+      ),
+    )
+    controller.enqueue(
+      encoder.encode(
+        formatSSE('content_block_stop', JSON.stringify({
+          type: 'content_block_stop',
+          index,
+        })),
+      ),
+    )
+  }
+
+  function finishStream(
+    controller: ReadableStreamDefaultController,
+    encoder: TextEncoder,
+    outputTokens: number,
+    inputTokens: number,
+    hadToolCalls: boolean,
+  ) {
+    // Use 'tool_use' stop reason when model made tool calls
+    const stopReason = hadToolCalls ? 'tool_use' : 'end_turn'
+
+    controller.enqueue(
+      encoder.encode(
+        formatSSE(
+          'message_delta',
+          JSON.stringify({
+            type: 'message_delta',
+            delta: { stop_reason: stopReason, stop_sequence: null },
+            usage: { output_tokens: outputTokens },
+          }),
+        ),
+      ),
+    )
+    controller.enqueue(
+      encoder.encode(
+        formatSSE(
+          'message_stop',
+          JSON.stringify({
+            type: 'message_stop',
+            'amazon-bedrock-invocationMetrics': {
+              inputTokenCount: inputTokens,
+              outputTokenCount: outputTokens,
+              invocationLatency: 0,
+              firstByteLatency: 0,
+            },
+            usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+          }),
+        ),
+      ),
+    )
+    controller.close()
+  }
+
+  return new Response(readable, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'x-request-id': messageId,
+    },
+  })
+}
+
+// ── Main fetch interceptor ──────────────────────────────────────────
+
+const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex/responses'
+
+export function createCodexFetch(
+  accessToken: string,
+): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
+  const accountId = extractAccountId(accessToken)
+
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = input instanceof Request ? input.url : String(input)
+
+    // Only intercept Anthropic API message calls
+    if (!url.includes('/v1/messages')) {
+      return globalThis.fetch(input, init)
+    }
+
+    // Parse the Anthropic request body
+    let anthropicBody: Record<string, unknown>
+    try {
+      const bodyText =
+        init?.body instanceof ReadableStream
+          ? await new Response(init.body).text()
+          : typeof init?.body === 'string'
+            ? init.body
+            : '{}'
+      anthropicBody = JSON.parse(bodyText)
+    } catch {
+      anthropicBody = {}
+    }
+
+    // Get current token (may have been refreshed)
+    const tokens = getCodexOAuthTokens()
+    const currentToken = tokens?.accessToken || accessToken
+
+    // Translate to Codex format
+    const { codexBody, codexModel } = translateToCodexBody(anthropicBody)
+
+    // Call Codex API
+    const codexResponse = await globalThis.fetch(CODEX_BASE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        Authorization: `Bearer ${currentToken}`,
+        'chatgpt-account-id': accountId,
+        originator: 'pi',
+        'OpenAI-Beta': 'responses=experimental',
+      },
+      body: JSON.stringify(codexBody),
+    })
+
+    if (!codexResponse.ok) {
+      const errorText = await codexResponse.text()
+      const errorBody = {
+        type: 'error',
+        error: {
+          type: 'api_error',
+          message: `Codex API error (${codexResponse.status}): ${errorText}`,
+        },
+      }
+      return new Response(JSON.stringify(errorBody), {
+        status: codexResponse.status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // Translate streaming response
+    return translateCodexStreamToAnthropic(codexResponse, codexModel)
+  }
+}

--- a/src/services/oauth/client.ts
+++ b/src/services/oauth/client.ts
@@ -43,6 +43,34 @@ export function parseScopes(scopeString?: string): string[] {
   return scopeString?.split(' ').filter(Boolean) ?? []
 }
 
+export function buildOpenAIAuthUrl({
+  codeChallenge,
+  state,
+  port,
+  isManual,
+}: {
+  codeChallenge: string
+  state: string
+  port: number
+  isManual: boolean
+}): string {
+  const authUrl = new URL(getOauthConfig().OPENAI_AUTHORIZE_URL)
+  authUrl.searchParams.append('client_id', getOauthConfig().OPENAI_CLIENT_ID)
+  authUrl.searchParams.append('response_type', 'code')
+  authUrl.searchParams.append(
+    'redirect_uri',
+    isManual
+      ? getOauthConfig().MANUAL_REDIRECT_URL
+      : `http://localhost:${port}/callback`,
+  )
+  authUrl.searchParams.append('scope', 'openai')
+  authUrl.searchParams.append('code_challenge', codeChallenge)
+  authUrl.searchParams.append('code_challenge_method', 'S256')
+  authUrl.searchParams.append('state', state)
+
+  return authUrl.toString()
+}
+
 export function buildAuthUrl({
   codeChallenge,
   state,

--- a/src/services/oauth/codex-client.ts
+++ b/src/services/oauth/codex-client.ts
@@ -61,6 +61,11 @@ type LocalServer = {
 
 // ── JWT helpers ───────────────────────────────────────────────────────────────
 
+/**
+ * Decodes the payload from a JWT token.
+ * @param token - The JWT token to decode
+ * @returns The decoded payload object, or null if decoding fails
+ */
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
   try {
     const parts = token.split('.')

--- a/src/services/oauth/codex-client.ts
+++ b/src/services/oauth/codex-client.ts
@@ -1,0 +1,394 @@
+/**
+ * Self-contained OpenAI Codex OAuth 2.0 PKCE client.
+ *
+ * This module handles the complete Codex login flow independently of the
+ * Anthropic OAuth client (client.ts). It manages:
+ * - PKCE challenge generation
+ * - A local HTTP server on port 1455 (required by OpenAI's registered redirect URI)
+ * - Authorization URL construction
+ * - Code exchange for access + refresh tokens
+ * - Account ID extraction from the returned JWT
+ * - Token refresh
+ *
+ * Based on the implementation in @mariozechner/pi-ai/dist/utils/oauth/openai-codex.js
+ * used by the openclaw project.
+ */
+import { createServer, type Server } from 'http'
+import { logEvent } from 'src/services/analytics/index.js'
+import {
+  CODEX_AUTHORIZE_URL,
+  CODEX_CLIENT_ID,
+  CODEX_JWT_AUTH_CLAIM,
+  CODEX_REDIRECT_URI,
+  CODEX_SCOPES,
+  CODEX_TOKEN_URL,
+} from '../../constants/codex-oauth.js'
+import { openBrowser } from '../../utils/browser.js'
+import { logError } from '../../utils/log.js'
+import { generateCodeChallenge, generateCodeVerifier, generateState } from './crypto.js'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type CodexTokens = {
+  /** OpenAI access token (JWT) */
+  accessToken: string
+  /** OpenAI refresh token */
+  refreshToken: string
+  /** Absolute epoch timestamp (ms) when the access token expires */
+  expiresAt: number
+  /** ChatGPT account ID extracted from the JWT */
+  accountId: string
+}
+
+type TokenSuccessResult = {
+  type: 'success'
+  access: string
+  refresh: string
+  expires: number
+}
+
+type TokenFailedResult = {
+  type: 'failed'
+}
+
+type TokenResult = TokenSuccessResult | TokenFailedResult
+
+type LocalServer = {
+  waitForCode: () => Promise<{ code: string } | null>
+  cancelWait: () => void
+  close: () => void
+}
+
+// ── JWT helpers ───────────────────────────────────────────────────────────────
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return null
+    const payload = parts[1] ?? ''
+    const decoded = Buffer.from(payload, 'base64url').toString('utf8')
+    return JSON.parse(decoded) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extracts the ChatGPT account ID from the OpenAI access token JWT.
+ * The account ID lives at payload["https://api.openai.com/auth"].chatgpt_account_id
+ */
+export function extractCodexAccountId(accessToken: string): string | null {
+  const payload = decodeJwtPayload(accessToken)
+  if (!payload) return null
+  const authClaim = payload[CODEX_JWT_AUTH_CLAIM]
+  if (!authClaim || typeof authClaim !== 'object') return null
+  const accountId = (authClaim as Record<string, unknown>).chatgpt_account_id
+  return typeof accountId === 'string' && accountId.length > 0 ? accountId : null
+}
+
+// ── Authorization URL ─────────────────────────────────────────────────────────
+
+/**
+ * Builds the OpenAI authorization URL with PKCE parameters.
+ * Returns the URL plus the code verifier (needed for token exchange) and state.
+ */
+export function buildCodexAuthUrl(): {
+  url: string
+  verifier: string
+  state: string
+} {
+  const verifier = generateCodeVerifier()
+  const challenge = generateCodeChallenge(verifier)
+  const state = generateState()
+
+  const url = new URL(CODEX_AUTHORIZE_URL)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', CODEX_CLIENT_ID)
+  url.searchParams.set('redirect_uri', CODEX_REDIRECT_URI)
+  url.searchParams.set('scope', CODEX_SCOPES)
+  url.searchParams.set('code_challenge', challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', state)
+  // OpenAI-specific parameters (matched from the pi-ai implementation)
+  url.searchParams.set('id_token_add_organizations', 'true')
+  url.searchParams.set('codex_cli_simplified_flow', 'true')
+  url.searchParams.set('originator', 'free-code')
+
+  return { url: url.toString(), verifier, state }
+}
+
+// ── Token Exchange & Refresh ──────────────────────────────────────────────────
+
+async function postToTokenUrl(body: URLSearchParams): Promise<TokenResult> {
+  try {
+    const response = await fetch(CODEX_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    })
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      logError(
+        new Error(
+          `[codex-oauth] token endpoint responded ${response.status}: ${text}`,
+        ),
+      )
+      return { type: 'failed' }
+    }
+    const json = (await response.json()) as {
+      access_token?: string
+      refresh_token?: string
+      expires_in?: number
+    }
+    if (!json.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
+      logError(new Error('[codex-oauth] token response missing required fields'))
+      return { type: 'failed' }
+    }
+    return {
+      type: 'success',
+      access: json.access_token,
+      refresh: json.refresh_token,
+      expires: Date.now() + json.expires_in * 1000,
+    }
+  } catch (err) {
+    logError(err as Error)
+    return { type: 'failed' }
+  }
+}
+
+/**
+ * Exchanges an authorization code for access + refresh tokens.
+ */
+export async function exchangeCodexCode(
+  code: string,
+  verifier: string,
+): Promise<CodexTokens> {
+  const result = await postToTokenUrl(
+    new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CODEX_CLIENT_ID,
+      code,
+      code_verifier: verifier,
+      redirect_uri: CODEX_REDIRECT_URI,
+    }),
+  )
+  if (result.type !== 'success') {
+    throw new Error('Codex token exchange failed. Please try again.')
+  }
+  const accountId = extractCodexAccountId(result.access)
+  if (!accountId) {
+    throw new Error('Failed to extract accountId from Codex token.')
+  }
+  return {
+    accessToken: result.access,
+    refreshToken: result.refresh,
+    expiresAt: result.expires,
+    accountId,
+  }
+}
+
+/**
+ * Refreshes an expired Codex access token.
+ */
+export async function refreshCodexToken(refreshToken: string): Promise<CodexTokens> {
+  const result = await postToTokenUrl(
+    new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CODEX_CLIENT_ID,
+    }),
+  )
+  if (result.type !== 'success') {
+    throw new Error('Codex token refresh failed. Please re-login.')
+  }
+  const accountId = extractCodexAccountId(result.access)
+  if (!accountId) {
+    throw new Error('Failed to extract accountId from refreshed Codex token.')
+  }
+  return {
+    accessToken: result.access,
+    refreshToken: result.refresh,
+    expiresAt: result.expires,
+    accountId,
+  }
+}
+
+// ── Local Callback Server ─────────────────────────────────────────────────────
+
+/**
+ * Starts a local HTTP server on port 1455 to capture the OAuth callback.
+ * Port 1455 is fixed — it is hardcoded in OpenAI's registered redirect URI
+ * for Codex CLI tools (http://localhost:1455/auth/callback).
+ *
+ * Falls back gracefully if port 1455 is already in use (the user will need
+ * to paste the redirect URL manually).
+ */
+export async function startCodexCallbackServer(expectedState: string): Promise<LocalServer> {
+  let settleWait: ((value: { code: string } | null) => void) | null = null
+  let server: Server | null = null
+
+  const waitPromise = new Promise<{ code: string } | null>((resolve) => {
+    settleWait = resolve
+  })
+
+  const doClose = () => {
+    if (server) {
+      server.removeAllListeners()
+      server.close()
+      server = null
+    }
+  }
+
+  const localServer: LocalServer = {
+    waitForCode: () => waitPromise,
+    cancelWait: () => {
+      settleWait?.(null)
+      settleWait = null
+    },
+    close: doClose,
+  }
+
+  return new Promise<LocalServer>((resolve) => {
+    const s = createServer((req, res) => {
+      try {
+        const url = new URL(req.url ?? '', 'http://localhost')
+        if (url.pathname !== '/auth/callback') {
+          res.writeHead(404)
+          res.end('Not found')
+          return
+        }
+        const stateParam = url.searchParams.get('state')
+        if (stateParam !== expectedState) {
+          res.writeHead(400)
+          res.end('State mismatch')
+          return
+        }
+        const code = url.searchParams.get('code')
+        if (!code) {
+          res.writeHead(400)
+          res.end('Missing authorization code')
+          return
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(
+          '<html><body><h2>✅ OpenAI authentication completed.</h2><p>You can close this window and return to your terminal.</p></body></html>',
+        )
+        settleWait?.({ code })
+        settleWait = null
+      } catch {
+        res.writeHead(500)
+        res.end('Internal error')
+      }
+    })
+
+    server = s
+
+    s.listen(1455, '127.0.0.1', () => {
+      resolve(localServer)
+    }).on('error', () => {
+      // Port 1455 is busy — resolve with a server that always returns null
+      // so the user falls back to manual paste.
+      resolve({
+        waitForCode: async () => null,
+        cancelWait: () => {},
+        close: () => {},
+      })
+    })
+  })
+}
+
+// ── Full OAuth Flow ───────────────────────────────────────────────────────────
+
+/**
+ * Runs the complete Codex OAuth 2.0 PKCE flow:
+ * 1. Builds the authorization URL
+ * 2. Starts a local callback server on port 1455
+ * 3. Opens the browser
+ * 4. Waits for the callback (or manual paste via onManualInput)
+ * 5. Exchanges the code for tokens
+ * 6. Returns the CodexTokens
+ *
+ * @param onUrlReady - Called with the auth URL so the UI can display it
+ * @param onManualInput - Optional: resolves with the pasted redirect URL/code
+ */
+export async function runCodexOAuthFlow(
+  onUrlReady: (url: string) => Promise<void>,
+  onManualInput?: () => Promise<string>,
+): Promise<CodexTokens> {
+  const { url, verifier, state } = buildCodexAuthUrl()
+  const callbackServer = await startCodexCallbackServer(state)
+
+  logEvent('tengu_oauth_codex_flow_start', {})
+
+  try {
+    await onUrlReady(url)
+    await openBrowser(url)
+
+    let code: string | undefined
+
+    if (onManualInput) {
+      // Race: browser callback vs. manual paste
+      const manualPromise = onManualInput().then((input) => {
+        callbackServer.cancelWait()
+        return input
+      })
+
+      const callbackResult = await callbackServer.waitForCode()
+      if (callbackResult?.code) {
+        code = callbackResult.code
+      } else {
+        // Callback didn't arrive — use manual input
+        const manualInput = await manualPromise
+        const parsed = parseCodexCallbackInput(manualInput, state)
+        code = parsed.code
+      }
+    } else {
+      const callbackResult = await callbackServer.waitForCode()
+      code = callbackResult?.code
+    }
+
+    if (!code) {
+      throw new Error('No authorization code received from Codex OAuth flow.')
+    }
+
+    logEvent('tengu_oauth_codex_code_received', {})
+    const tokens = await exchangeCodexCode(code, verifier)
+    logEvent('tengu_oauth_codex_success', {})
+    return tokens
+  } catch (err) {
+    logEvent('tengu_oauth_codex_error', {})
+    throw err
+  } finally {
+    callbackServer.close()
+  }
+}
+
+/**
+ * Parses a manually pasted callback input (could be the full redirect URL
+ * or just the raw code).
+ */
+function parseCodexCallbackInput(
+  input: string,
+  expectedState: string,
+): { code: string | undefined } {
+  const value = input.trim()
+  if (!value) return { code: undefined }
+
+  try {
+    const url = new URL(value)
+    const urlState = url.searchParams.get('state')
+    if (urlState && urlState !== expectedState) {
+      throw new Error('State mismatch in pasted URL')
+    }
+    return { code: url.searchParams.get('code') ?? undefined }
+  } catch {
+    // Not a URL — treat as raw code
+  }
+
+  if (value.includes('code=')) {
+    const params = new URLSearchParams(value)
+    return { code: params.get('code') ?? undefined }
+  }
+
+  return { code: value }
+}

--- a/src/services/oauth/crypto.ts
+++ b/src/services/oauth/crypto.ts
@@ -1,5 +1,10 @@
 import { createHash, randomBytes } from 'crypto'
 
+/**
+ * Encodes a buffer to base64URL format (RFC 4648).
+ * @param buffer - The buffer to encode
+ * @returns Base64URL encoded string
+ */
 function base64URLEncode(buffer: Buffer): string {
   return buffer
     .toString('base64')
@@ -8,16 +13,29 @@ function base64URLEncode(buffer: Buffer): string {
     .replace(/=/g, '')
 }
 
+/**
+ * Generates a PKCE code verifier for OAuth 2.0 authentication.
+ * @returns A cryptographically random code verifier string
+ */
 export function generateCodeVerifier(): string {
   return base64URLEncode(randomBytes(32))
 }
 
+/**
+ * Generates a PKCE code challenge from a code verifier.
+ * @param verifier - The code verifier to generate challenge for
+ * @returns The SHA256 hash of the verifier, base64URL encoded
+ */
 export function generateCodeChallenge(verifier: string): string {
   const hash = createHash('sha256')
   hash.update(verifier)
   return base64URLEncode(hash.digest())
 }
 
+/**
+ * Generates a random state parameter for OAuth 2.0 authentication.
+ * @returns A cryptographically random state string
+ */
 export function generateState(): string {
   return base64URLEncode(randomBytes(32))
 }

--- a/src/services/oauth/getOauthProfile.ts
+++ b/src/services/oauth/getOauthProfile.ts
@@ -4,6 +4,11 @@ import type { OAuthProfileResponse } from 'src/services/oauth/types.js'
 import { getAnthropicApiKey } from 'src/utils/auth.js'
 import { getGlobalConfig } from 'src/utils/config.js'
 import { logError } from 'src/utils/log.js'
+
+/**
+ * Gets OAuth profile information using an API key for authentication.
+ * @returns OAuth profile response or undefined if not available
+ */
 export async function getOauthProfileFromApiKey(): Promise<
   OAuthProfileResponse | undefined
 > {
@@ -34,6 +39,11 @@ export async function getOauthProfileFromApiKey(): Promise<
   }
 }
 
+/**
+ * Gets OAuth profile information using an OAuth access token.
+ * @param accessToken - The OAuth access token for authentication
+ * @returns OAuth profile response or undefined if request fails
+ */
 export async function getOauthProfileFromOauthToken(
   accessToken: string,
 ): Promise<OAuthProfileResponse | undefined> {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1627,14 +1627,19 @@ export function isClaudeAISubscriber(): boolean {
 }
 
 export function isCodexSubscriber(): boolean {
-  // Check if we're using OpenAI API
-  if (getAPIProvider() !== 'openai') {
-    return false
+  // Check if we're using OpenAI API via environment variable
+  if (getAPIProvider() === 'openai') {
+    return true
   }
 
-  // For now, return true if OpenAI provider is configured
-  // This can be extended to check for specific token scopes when available
-  return true
+  // Check if we have OpenAI OAuth tokens
+  const config = getGlobalConfig()
+  const openaiTokens = config?.openaiOauthTokens
+  if (openaiTokens?.access_token && openaiTokens?.scopes?.includes('codex')) {
+    return true
+  }
+
+  return false
 }
 
 /**

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1626,6 +1626,17 @@ export function isClaudeAISubscriber(): boolean {
   return shouldUseClaudeAIAuth(getClaudeAIOAuthTokens()?.scopes)
 }
 
+export function isCodexSubscriber(): boolean {
+  // Check if we're using OpenAI API
+  if (getAPIProvider() !== 'openai') {
+    return false
+  }
+
+  // For now, return true if OpenAI provider is configured
+  // This can be extended to check for specific token scopes when available
+  return true
+}
+
 /**
  * Check if the user is authenticated via OpenAI Codex OAuth.
  * Returns true when a valid Codex access token is present in the config.

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -24,6 +24,7 @@ import {
   refreshOAuthToken,
   shouldUseClaudeAIAuth,
 } from '../services/oauth/client.js'
+import type { CodexTokens } from '../services/oauth/codex-client.js'
 import { getOauthProfileFromOauthToken } from '../services/oauth/getOauthProfile.js'
 import type { OAuthTokens, SubscriptionType } from '../services/oauth/types.js'
 import {
@@ -1310,6 +1311,62 @@ export function clearOAuthTokenCache(): void {
   clearKeychainCache()
 }
 
+// ── Codex OAuth token storage ────────────────────────────────────────────────
+// These functions manage OpenAI Codex tokens separately from Anthropic's
+// claudeAiOauth keychain entry. Codex tokens are stored in the GlobalConfig
+// JSON file (not in the system keychain) and are only ever sent to OpenAI's
+// API, never to Anthropic's servers.
+
+/**
+ * Saves the OpenAI Codex OAuth tokens to GlobalConfig.
+ * Does NOT overwrite or interfere with Anthropic's claudeAiOauth block.
+ */
+export function saveCodexOAuthTokens(tokens: CodexTokens): void {
+  saveGlobalConfig((cfg) => ({
+    ...cfg,
+    codexOAuth: {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      accountId: tokens.accountId,
+    },
+  }))
+}
+
+/**
+ * Retrieves the stored Codex OAuth tokens from GlobalConfig.
+ * Returns null if no Codex tokens are stored.
+ */
+export function getCodexOAuthTokens(): CodexTokens | null {
+  const cfg = getGlobalConfig()
+  const stored = cfg.codexOAuth
+  if (
+    !stored?.accessToken ||
+    !stored.refreshToken ||
+    !stored.expiresAt ||
+    !stored.accountId
+  ) {
+    return null
+  }
+  return {
+    accessToken: stored.accessToken,
+    refreshToken: stored.refreshToken,
+    expiresAt: stored.expiresAt,
+    accountId: stored.accountId,
+  }
+}
+
+/**
+ * Removes Codex OAuth tokens from GlobalConfig (e.g., on logout).
+ */
+export function clearCodexOAuthTokens(): void {
+  saveGlobalConfig((cfg) => {
+    const { codexOAuth: _removed, ...rest } = cfg
+    return rest as typeof cfg
+  })
+}
+
+
 let lastCredentialsMtimeMs = 0
 
 // Cross-process staleness: another CC instance may write fresh tokens to
@@ -1567,6 +1624,15 @@ export function isClaudeAISubscriber(): boolean {
   }
 
   return shouldUseClaudeAIAuth(getClaudeAIOAuthTokens()?.scopes)
+}
+
+/**
+ * Check if the user is authenticated via OpenAI Codex OAuth.
+ * Returns true when a valid Codex access token is present in the config.
+ */
+export function isCodexSubscriber(): boolean {
+  const tokens = getCodexOAuthTokens()
+  return !!tokens?.accessToken
 }
 
 /**

--- a/src/utils/codex-fetch-adapter.ts
+++ b/src/utils/codex-fetch-adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * OpenAI Codex API adapter for Claude Code
+ * Provides compatibility layer between Claude's API expectations and OpenAI's Codex API
+ */
+
+import type { Message } from '../types/message.js'
+import { logError } from './log.js'
+
+/**
+ * OpenAI message format for API requests
+ */
+interface OpenAIMessage {
+  role: 'system' | 'user' | 'assistant'
+  content: string | Array<{
+    type: 'text' | 'image_url'
+    text?: string
+    image_url?: {
+      url: string
+    }
+  }>
+}
+
+/**
+ * OpenAI API response format
+ */
+interface OpenAIResponse {
+  id: string
+  object: string
+  created: number
+  model: string
+  choices: Array<{
+    index: number
+    message: {
+      role: string
+      content: string
+    }
+    finish_reason: string
+  }>
+  usage: {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+  }
+}
+
+/**
+ * Convert Claude Code message format to OpenAI format
+ */
+function convertToOpenAIMessage(message: Message): OpenAIMessage {
+  if (typeof message.content === 'string') {
+    return {
+      role: message.role === 'human' ? 'user' : message.role as 'system' | 'assistant',
+      content: message.content,
+    }
+  }
+
+  // Handle multi-modal content
+  const content: Array<any> = []
+
+  for (const item of message.content) {
+    if (item.type === 'text') {
+      content.push({
+        type: 'text',
+        text: item.text,
+      })
+    } else if (item.type === 'image') {
+      // Convert Anthropic base64 image schema to OpenAI format
+      content.push({
+        type: 'image_url',
+        image_url: {
+          url: item.source.type === 'base64'
+            ? `data:${item.source.media_type};base64,${item.source.data}`
+            : item.source.data
+        }
+      })
+    }
+  }
+
+  return {
+    role: message.role === 'human' ? 'user' : message.role as 'system' | 'assistant',
+    content,
+  }
+}
+
+/**
+ * Make a request to OpenAI Codex API
+ */
+export async function fetchCodexResponse(
+  messages: Message[],
+  model: string,
+  options: {
+    apiKey?: string
+    baseUrl?: string
+    stream?: boolean
+  } = {}
+): Promise<OpenAIResponse> {
+  const { apiKey, baseUrl = 'https://api.openai.com/v1', stream = false } = options
+
+  if (!apiKey) {
+    throw new Error('OpenAI API key is required for Codex requests')
+  }
+
+  const openAIMessages = messages.map(convertToOpenAIMessage)
+
+  const requestBody = {
+    model,
+    messages: openAIMessages,
+    stream,
+    temperature: 0.7,
+    max_tokens: 4096,
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(requestBody),
+    })
+
+    if (!response.ok) {
+      throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`)
+    }
+
+    const data = await response.json() as OpenAIResponse
+    return data
+  } catch (error) {
+    logError(error)
+    throw error
+  }
+}
+
+/**
+ * Convert OpenAI response to Claude Code format
+ */
+export function convertFromOpenAIResponse(response: OpenAIResponse): {
+  content: string
+  usage: {
+    input_tokens: number
+    output_tokens: number
+  }
+} {
+  const choice = response.choices[0]
+  if (!choice) {
+    throw new Error('No choices in OpenAI response')
+  }
+
+  return {
+    content: choice.message.content,
+    usage: {
+      input_tokens: response.usage.prompt_tokens,
+      output_tokens: response.usage.completion_tokens,
+    },
+  }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -587,6 +587,14 @@ export type GlobalConfig = {
   // CURRENT_MIGRATION_VERSION, runMigrations() skips all sync migrations
   // (avoiding 11× saveGlobalConfig lock+re-read on every startup).
   migrationVersion?: number
+
+  // OpenAI OAuth tokens for Codex API access
+  openaiOauthTokens?: {
+    access_token: string
+    refresh_token?: string
+    scopes?: string[]
+    expires_at?: number
+  }
 }
 
 /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -227,6 +227,18 @@ export type GlobalConfig = {
   hasSeenUltraplanTerms?: boolean // ant-only: whether the one-time CCR terms notice has been shown in the ultraplan launch dialog
   hasResetAutoModeOptInForDefaultOffer?: boolean // ant-only: one-shot migration guard, re-prompts churned auto-mode users
   oauthAccount?: AccountInfo
+
+  /**
+   * OpenAI Codex OAuth tokens, stored separately from Anthropic credentials.
+   * These are acquired via the Codex OAuth flow (auth.openai.com) and are used
+   * as Bearer tokens against OpenAI's API — they are never sent to Anthropic servers.
+   */
+  codexOAuth?: {
+    accessToken: string
+    refreshToken: string
+    expiresAt: number
+    accountId: string
+  }
   iterm2KeyBindingInstalled?: boolean // Legacy - keeping for backward compatibility
   editorMode?: EditorMode
   bypassPermissionsModeAccepted?: boolean

--- a/src/utils/logoV2Utils.ts
+++ b/src/utils/logoV2Utils.ts
@@ -1,7 +1,7 @@
 import { getDirectConnectServerUrl, getSessionId } from '../bootstrap/state.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import type { LogOption } from '../types/logs.js'
-import { getSubscriptionName, isClaudeAISubscriber } from './auth.js'
+import { getSubscriptionName, isClaudeAISubscriber, isCodexSubscriber } from './auth.js'
 import { getCwd } from './cwd.js'
 import { getDisplayPath } from './file.js'
 import {
@@ -258,7 +258,9 @@ export function getLogoDisplayData(): {
     : displayPath
   const billingType = isClaudeAISubscriber()
     ? getSubscriptionName()
-    : 'API Usage Billing'
+    : isCodexSubscriber()
+      ? 'Codex API Billing'
+      : 'API Usage Billing'
   const agentName = getInitialSettings().agent
 
   return {

--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -11,6 +11,7 @@ export const CLAUDE_3_7_SONNET_CONFIG = {
   bedrock: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
   vertex: 'claude-3-7-sonnet@20250219',
   foundry: 'claude-3-7-sonnet',
+  openai: 'claude-3-7-sonnet-20250219',
 } as const satisfies ModelConfig
 
 export const CLAUDE_3_5_V2_SONNET_CONFIG = {
@@ -18,6 +19,7 @@ export const CLAUDE_3_5_V2_SONNET_CONFIG = {
   bedrock: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
   vertex: 'claude-3-5-sonnet-v2@20241022',
   foundry: 'claude-3-5-sonnet',
+  openai: 'claude-3-5-sonnet-20241022',
 } as const satisfies ModelConfig
 
 export const CLAUDE_3_5_HAIKU_CONFIG = {
@@ -25,6 +27,7 @@ export const CLAUDE_3_5_HAIKU_CONFIG = {
   bedrock: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
   vertex: 'claude-3-5-haiku@20241022',
   foundry: 'claude-3-5-haiku',
+  openai: 'claude-3-5-haiku-20241022',
 } as const satisfies ModelConfig
 
 export const CLAUDE_HAIKU_4_5_CONFIG = {
@@ -32,6 +35,7 @@ export const CLAUDE_HAIKU_4_5_CONFIG = {
   bedrock: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   vertex: 'claude-haiku-4-5@20251001',
   foundry: 'claude-haiku-4-5',
+  openai: 'claude-haiku-4-5-20251001',
 } as const satisfies ModelConfig
 
 export const CLAUDE_SONNET_4_CONFIG = {
@@ -39,6 +43,7 @@ export const CLAUDE_SONNET_4_CONFIG = {
   bedrock: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
   vertex: 'claude-sonnet-4@20250514',
   foundry: 'claude-sonnet-4',
+  openai: 'claude-sonnet-4-20250514',
 } as const satisfies ModelConfig
 
 export const CLAUDE_SONNET_4_5_CONFIG = {
@@ -46,6 +51,7 @@ export const CLAUDE_SONNET_4_5_CONFIG = {
   bedrock: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
   vertex: 'claude-sonnet-4-5@20250929',
   foundry: 'claude-sonnet-4-5',
+  openai: 'claude-sonnet-4-5-20250929',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_CONFIG = {
@@ -53,6 +59,7 @@ export const CLAUDE_OPUS_4_CONFIG = {
   bedrock: 'us.anthropic.claude-opus-4-20250514-v1:0',
   vertex: 'claude-opus-4@20250514',
   foundry: 'claude-opus-4',
+  openai: 'claude-opus-4-20250514',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_1_CONFIG = {
@@ -60,6 +67,7 @@ export const CLAUDE_OPUS_4_1_CONFIG = {
   bedrock: 'us.anthropic.claude-opus-4-1-20250805-v1:0',
   vertex: 'claude-opus-4-1@20250805',
   foundry: 'claude-opus-4-1',
+  openai: 'claude-opus-4-1-20250805',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_5_CONFIG = {
@@ -67,6 +75,7 @@ export const CLAUDE_OPUS_4_5_CONFIG = {
   bedrock: 'us.anthropic.claude-opus-4-5-20251101-v1:0',
   vertex: 'claude-opus-4-5@20251101',
   foundry: 'claude-opus-4-5',
+  openai: 'claude-opus-4-5-20251101',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_6_CONFIG = {
@@ -74,6 +83,7 @@ export const CLAUDE_OPUS_4_6_CONFIG = {
   bedrock: 'us.anthropic.claude-opus-4-6-v1',
   vertex: 'claude-opus-4-6',
   foundry: 'claude-opus-4-6',
+  openai: 'claude-opus-4-6',
 } as const satisfies ModelConfig
 
 export const CLAUDE_SONNET_4_6_CONFIG = {
@@ -81,6 +91,32 @@ export const CLAUDE_SONNET_4_6_CONFIG = {
   bedrock: 'us.anthropic.claude-sonnet-4-6',
   vertex: 'claude-sonnet-4-6',
   foundry: 'claude-sonnet-4-6',
+  openai: 'claude-sonnet-4-6',
+} as const satisfies ModelConfig
+
+// OpenAI Codex models
+export const GPT_5_4_CONFIG = {
+  firstParty: 'gpt-5.4',
+  bedrock: 'gpt-5.4',
+  vertex: 'gpt-5.4',
+  foundry: 'gpt-5.4',
+  openai: 'gpt-5.4',
+} as const satisfies ModelConfig
+
+export const GPT_5_3_CODEX_CONFIG = {
+  firstParty: 'gpt-5.3-codex',
+  bedrock: 'gpt-5.3-codex',
+  vertex: 'gpt-5.3-codex',
+  foundry: 'gpt-5.3-codex',
+  openai: 'gpt-5.3-codex',
+} as const satisfies ModelConfig
+
+export const GPT_5_4_MINI_CONFIG = {
+  firstParty: 'gpt-5.4-mini',
+  bedrock: 'gpt-5.4-mini',
+  vertex: 'gpt-5.4-mini',
+  foundry: 'gpt-5.4-mini',
+  openai: 'gpt-5.4-mini',
 } as const satisfies ModelConfig
 
 // @[MODEL LAUNCH]: Register the new config here.
@@ -96,6 +132,10 @@ export const ALL_MODEL_CONFIGS = {
   opus41: CLAUDE_OPUS_4_1_CONFIG,
   opus45: CLAUDE_OPUS_4_5_CONFIG,
   opus46: CLAUDE_OPUS_4_6_CONFIG,
+  // OpenAI Codex models
+  gpt54: GPT_5_4_CONFIG,
+  gpt53codex: GPT_5_3_CODEX_CONFIG,
+  gpt54mini: GPT_5_4_MINI_CONFIG,
 } as const satisfies Record<string, ModelConfig>
 
 export type ModelKey = keyof typeof ALL_MODEL_CONFIGS

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -9,6 +9,7 @@ import { getMainLoopModelOverride } from '../../bootstrap/state.js'
 import {
   getSubscriptionType,
   isClaudeAISubscriber,
+  isCodexSubscriber,
   isMaxSubscriber,
   isProSubscriber,
   isTeamPremiumSubscriber,
@@ -190,6 +191,11 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
     )
   }
 
+  // Codex users get GPT-5.3 Codex as default
+  if (isCodexSubscriber()) {
+    return getModelStrings().gpt53codex
+  }
+
   // Max users get Opus as default
   if (isMaxSubscriber()) {
     return getDefaultOpusModel() + (isOpus1mMergeEnabled() ? '[1m]' : '')
@@ -267,6 +273,16 @@ export function firstPartyNameToCanonical(name: ModelName): ModelShortName {
   if (name.includes('claude-3-haiku')) {
     return 'claude-3-haiku'
   }
+  // OpenAI GPT models
+  if (name.includes('gpt-5.4-mini')) {
+    return 'gpt-5.4-mini'
+  }
+  if (name.includes('gpt-5.4')) {
+    return 'gpt-5.4'
+  }
+  if (name.includes('gpt-5.3-codex')) {
+    return 'gpt-5.3-codex'
+  }
   const match = name.match(/(claude-(\d+-\d+-)?\w+)/)
   if (match && match[1]) {
     return match[1]
@@ -293,7 +309,7 @@ export function getClaudeAiUserDefaultModelDescription(
   fastMode = false,
 ): string {
   if (isCodexSubscriber()) {
-    return 'Codex 5.2 · Best for everyday coding tasks'
+    return 'GPT-5.3 Codex · Optimized for code generation and understanding'
   }
   if (isMaxSubscriber() || isTeamPremiumSubscriber()) {
     if (isOpus1mMergeEnabled()) {
@@ -397,6 +413,12 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
       return 'Haiku 4.5'
     case getModelStrings().haiku35:
       return 'Haiku 3.5'
+    case getModelStrings().gpt54:
+      return 'GPT-5.4'
+    case getModelStrings().gpt53codex:
+      return 'GPT-5.3 Codex'
+    case getModelStrings().gpt54mini:
+      return 'GPT-5.4 Mini'
     default:
       return null
   }
@@ -630,6 +652,16 @@ export function getMarketingNameForModel(modelId: string): string | undefined {
   }
   if (canonical.includes('claude-3-5-haiku')) {
     return 'Claude 3.5 Haiku'
+  }
+  // OpenAI Codex models
+  if (canonical.includes('gpt-5.4-mini')) {
+    return 'GPT-5.4 Mini'
+  }
+  if (canonical.includes('gpt-5.4')) {
+    return 'GPT-5.4'
+  }
+  if (canonical.includes('gpt-5.3-codex')) {
+    return 'GPT-5.3 Codex'
   }
 
   return undefined

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -12,7 +12,9 @@ import {
   isMaxSubscriber,
   isProSubscriber,
   isTeamPremiumSubscriber,
+  isCodexSubscriber,
 } from '../auth.js'
+import { getAntModelOverrideConfig, resolveAntModel } from './antModels.js'
 import {
   has1mContext,
   is1mContextDisabled,
@@ -176,6 +178,10 @@ export function getRuntimeMainLoopModel(params: {
  * @returns The default model setting to use
  */
 export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
+  if (isCodexSubscriber()) {
+    return 'gpt-5.2-codex'
+  }
+
   // Ants default to defaultModel from flag config, or Opus 1M if not configured
   if (process.env.USER_TYPE === 'ant') {
     return (
@@ -286,6 +292,9 @@ export function getCanonicalName(fullModelName: ModelName): ModelShortName {
 export function getClaudeAiUserDefaultModelDescription(
   fastMode = false,
 ): string {
+  if (isCodexSubscriber()) {
+    return 'Codex 5.2 · Best for everyday coding tasks'
+  }
   if (isMaxSubscriber() || isTeamPremiumSubscriber()) {
     if (isOpus1mMergeEnabled()) {
       return `Opus 4.6 with 1M context · Most capable for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`
@@ -347,6 +356,16 @@ export function renderModelSetting(setting: ModelName | ModelAlias): string {
  * if the model is not recognized as a public model.
  */
 export function getPublicModelDisplayName(model: ModelName): string | null {
+  if (model.includes('gpt-') || model.includes('codex')) {
+    if (model === 'gpt-5.2-codex') return 'Codex 5.2'
+    if (model === 'gpt-5.1-codex') return 'Codex 5.1'
+    if (model === 'gpt-5.1-codex-mini') return 'Codex 5.1 Mini'
+    if (model === 'gpt-5.1-codex-max') return 'Codex 5.1 Max'
+    if (model === 'gpt-5.4') return 'GPT 5.4'
+    if (model === 'gpt-5.2') return 'GPT 5.2'
+    return model
+  }
+
   switch (model) {
     case getModelStrings().opus46:
       return 'Opus 4.6'
@@ -425,6 +444,9 @@ export function renderModelName(model: ModelName): string {
 export function getPublicModelName(model: ModelName): string {
   const publicName = getPublicModelDisplayName(model)
   if (publicName) {
+    if (model.includes('gpt-') || model.includes('codex')) {
+      return publicName
+    }
     return `Claude ${publicName}`
   }
   return `Claude (${model})`

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -180,7 +180,7 @@ export function getRuntimeMainLoopModel(params: {
  */
 export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   if (isCodexSubscriber()) {
-    return 'gpt-5.2-codex'
+    return getModelStrings().gpt53codex
   }
 
   // Ants default to defaultModel from flag config, or Opus 1M if not configured
@@ -189,11 +189,6 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
       getAntModelOverrideConfig()?.defaultModel ??
       getDefaultOpusModel() + '[1m]'
     )
-  }
-
-  // Codex users get GPT-5.3 Codex as default
-  if (isCodexSubscriber()) {
-    return getModelStrings().gpt53codex
   }
 
   // Max users get Opus as default

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -2,6 +2,7 @@
 import { getInitialMainLoopModel } from '../../bootstrap/state.js'
 import {
   isClaudeAISubscriber,
+  isCodexSubscriber,
   isMaxSubscriber,
   isTeamPremiumSubscriber,
 } from '../auth.js'
@@ -208,6 +209,34 @@ function getHaikuOption(): ModelOption {
     : getHaiku35Option()
 }
 
+// OpenAI Codex model options
+function getGpt54Option(): ModelOption {
+  return {
+    value: 'gpt-5.4',
+    label: 'GPT-5.4',
+    description: 'GPT-5.4 · Advanced reasoning and code generation',
+    descriptionForModel: 'GPT-5.4 - advanced reasoning and code generation capabilities',
+  }
+}
+
+function getGpt53CodexOption(): ModelOption {
+  return {
+    value: 'gpt-5.3-codex',
+    label: 'GPT-5.3 Codex',
+    description: 'GPT-5.3 Codex · Optimized for code generation and understanding',
+    descriptionForModel: 'GPT-5.3 Codex - specialized for code generation and understanding',
+  }
+}
+
+function getGpt54MiniOption(): ModelOption {
+  return {
+    value: 'gpt-5.4-mini',
+    label: 'GPT-5.4 Mini',
+    description: 'GPT-5.4 Mini · Fast and efficient for simple tasks',
+    descriptionForModel: 'GPT-5.4 Mini - fast and efficient for simple coding tasks',
+  }
+}
+
 function getMaxOpusOption(fastMode = false): ModelOption {
   return {
     value: 'opus',
@@ -284,6 +313,16 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
       getSonnet46Option(),
       getSonnet46_1MOption(),
       getHaiku45Option(),
+    ]
+  }
+
+  // Codex subscribers get OpenAI model options
+  if (isCodexSubscriber()) {
+    return [
+      getDefaultOptionForUser(),
+      getGpt54Option(),
+      getGpt53CodexOption(),
+      getGpt54MiniOption(),
     ]
   }
 

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -1,7 +1,7 @@
 import type { AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS } from '../../services/analytics/index.js'
 import { isEnvTruthy } from '../envUtils.js'
 
-export type APIProvider = 'firstParty' | 'bedrock' | 'vertex' | 'foundry'
+export type APIProvider = 'firstParty' | 'bedrock' | 'vertex' | 'foundry' | 'openai'
 
 export function getAPIProvider(): APIProvider {
   return isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)
@@ -10,7 +10,9 @@ export function getAPIProvider(): APIProvider {
       ? 'vertex'
       : isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY)
         ? 'foundry'
-        : 'firstParty'
+        : isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)
+          ? 'openai'
+          : 'firstParty'
 }
 
 export function getAPIProviderForStatsig(): AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS {

--- a/src/utils/model/validateModel.ts
+++ b/src/utils/model/validateModel.ts
@@ -41,6 +41,14 @@ export async function validateModel(
     return { valid: true }
   }
 
+  // Check if it's a known Codex/OpenAI model (skip Anthropic API validation)
+  const { isCodexSubscriber } = await import('../auth.js')
+  const { isCodexModel } = await import('../../services/api/codex-fetch-adapter.js')
+  if (isCodexSubscriber() && isCodexModel(normalizedModel)) {
+    validModelCache.set(normalizedModel, true)
+    return { valid: true }
+  }
+
   // Check if it matches ANTHROPIC_CUSTOM_MODEL_OPTION (pre-validated by the user)
   if (normalizedModel === process.env.ANTHROPIC_CUSTOM_MODEL_OPTION) {
     return { valid: true }

--- a/src/utils/ripgrep.ts
+++ b/src/utils/ripgrep.ts
@@ -33,8 +33,8 @@ const getRipgrepConfig = memoize((): RipgrepConfig => {
     process.env.USE_BUILTIN_RIPGREP,
   )
 
-  // Try system ripgrep if user wants it
-  if (userWantsSystemRipgrep) {
+  // Try system ripgrep if user wants it (or if nothing is specified = default to system if available)
+  if (userWantsSystemRipgrep || process.env.USE_BUILTIN_RIPGREP === undefined) {
     const { cmd: systemPath } = findExecutable('rg', [])
     if (systemPath !== 'rg') {
       // SECURITY: Use command name 'rg' instead of systemPath to prevent PATH hijacking


### PR DESCRIPTION
# Codex API Support: Feature Parity & UI Overhaul

## Summary
This pull request introduces full feature parity and explicit UI support for the OpenAI Codex backend (`chatgpt.com/backend-api/codex/responses`). The codebase is now entirely backend-agnostic and smoothly transitions between Anthropic Claude and OpenAI Codex schemas based on current authentication, without losing features like reasoning animations, token billing, or multi-modal visual inputs.

## Key Changes

### 1. Codex API Gateway Adapter (`codex-fetch-adapter.ts`)
- **Native Vision Translation**: Anthropic `base64` image schemas now map precisely to the Codex expected `input_image` payloads.
- **Strict Payload Mapping**: Refactored the internal mapping logic to translate `msg.content` items precisely into `input_text`, sidestepping OpenAI's strict `v1/responses` validation rules (`Invalid value: 'text'`).
- **Tool Logic Fixes**: Properly routed `tool_result` items into top-level `function_call_output` objects to guarantee that local CLI tool executions (File Reads, Bash loops) cleanly feed back into Codex logic without throwing "No tool output found" errors.
- **Cache Stripping**: Cleanly stripped Anthropic-only `cache_control` annotations from tool bindings and prompts prior to transmission so the Codex API doesn't reject malformed JSON.

### 2. Deep UI & Routing Integration
- **Model Cleanups (`model.ts`)**: Updated `getPublicModelDisplayName` and `getClaudeAiUserDefaultModelDescription` to recognize Codex GPT strings. Models like `gpt-5.1-codex-max` now beautifully map to `Codex 5.1 Max` in the CLI visual outputs instead of passing the raw proxy IDs.
- **Default Reroutes**: Made `getDefaultMainLoopModelSetting` aware of `isCodexSubscriber()`, automatically defaulting to `gpt-5.2-codex` instead of `sonnet46`.
- **Billing Visuals (`logoV2Utils.ts`)**: Refactored `formatModelAndBilling` logic to render `Codex API Billing` proudly inside the terminal header when authenticated.

### 3. Reasoning & Metrics Support
- **Thinking Animations**: `codex-fetch-adapter` now intentionally intercepts the proprietary `response.reasoning.delta` SSE frames emitted by `codex-max` models. It wraps them into Anthropic `<thinking>` events, ensuring the standard CLI "Thinking..." spinner continues to function flawlessly for OpenAI reasoning.
- **Token Accuracy**: Bound logic to track `response.completed` completion events, fetching `usage.input_tokens` and `output_tokens`. These are injected natively into the final `message_stop` token handler, meaning Codex queries correctly trigger the terminal's Token/Price tracker summary logic.

### 4. Git Housekeeping
- Configured `.gitignore` to securely and durably exclude the `openclaw/` gateway directory from staging commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI Codex backend support with OAuth login and selectable Codex models for subscribers.
  * UI: Codex-aware default model selection and terminal billing header showing “Codex API Billing”.
  * Console login flow now offers Codex as a login method with token persistence.

* **Documentation**
  * Added CLAUDE.md and changes.md documenting build/run guidance and Codex integration.

* **Bug Fixes**
  * Improved ripgrep system-binary detection and more robust OAuth organization error handling.

* **Chores**
  * Ignored local gateway directory in VCS; added CLI dev fallback for version/build info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->