### PR TITLE
fix: handle EEXIST error in build script

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -121,8 +121,10 @@ const version = dev ? getDevVersion(pkg.version) : pkg.version
 
 try {
   mkdirSync(dirname(outfile), { recursive: true })
-} catch {
-  // Ignore EEXIST - directory already exists
+} catch (e: unknown) {
+  if ((e as NodeJS.ErrnoException).code !== 'EEXIST') {
+    throw e
+  }
 }
 
 const externals = [

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -119,7 +119,11 @@ const outfile = compile
 const buildTime = new Date().toISOString()
 const version = dev ? getDevVersion(pkg.version) : pkg.version
 
-mkdirSync(dirname(outfile), { recursive: true })
+try {
+  mkdirSync(dirname(outfile), { recursive: true })
+} catch {
+  // Ignore EEXIST - directory already exists
+}
 
 const externals = [
   '@ant/*',


### PR DESCRIPTION
Bun's mkdirSync throws EEXIST when the directory already exists, unlike Node.js which ignores it. Add try-catch to handle this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build process robustness by enhancing error handling for directory creation, allowing builds to continue when directories already exist while properly handling other failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->