### PR TITLE
fix: narrow catch block to EEXIST only in build script 

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -121,8 +121,10 @@ const version = dev ? getDevVersion(pkg.version) : pkg.version
 
 try {
   mkdirSync(dirname(outfile), { recursive: true })
-} catch {
-  // Ignore EEXIST - directory already exists
+} catch (e: unknown) {
+  if ((e as NodeJS.ErrnoException).code !== 'EEXIST') {
+    throw e
+  }
 }
 
 const externals = [

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -119,7 +119,11 @@ const outfile = compile
 const buildTime = new Date().toISOString()
 const version = dev ? getDevVersion(pkg.version) : pkg.version
 
-mkdirSync(dirname(outfile), { recursive: true })
+try {
+  mkdirSync(dirname(outfile), { recursive: true })
+} catch {
+  // Ignore EEXIST - directory already exists
+}
 
 const externals = [
   '@ant/*',


### PR DESCRIPTION
[fix: narrow catch block to EEXIST only in build script](https://github.com/paoloanzn/free-code/commit/02f27c37d51447c1ff0edfec3afbc45b5d118518)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build script reliability by improving error handling for directory operations during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->