### PR TITLE
feat: Enable cached microcompact for all models and third-party APIs

### DIFF
--- a/src/constants/betas.ts
+++ b/src/constants/betas.ts
@@ -16,6 +16,9 @@ export const EFFORT_BETA_HEADER = 'effort-2025-11-24'
 export const TASK_BUDGETS_BETA_HEADER = 'task-budgets-2026-03-13'
 export const PROMPT_CACHING_SCOPE_BETA_HEADER =
   'prompt-caching-scope-2026-01-05'
+// Cache editing beta for advanced context compression (CACHED_MICROCOMPACT)
+// Uses context-management beta which provides cache_edits functionality
+export const CACHE_EDITING_BETA_HEADER = 'context-management-2025-06-27'
 export const FAST_MODE_BETA_HEADER = 'fast-mode-2026-02-01'
 export const REDACT_THINKING_BETA_HEADER = 'redact-thinking-2026-02-12'
 export const TOKEN_EFFICIENT_TOOLS_BETA_HEADER =

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -1433,7 +1433,7 @@ async function* queryModel(
     if (
       !cacheEditingHeaderLatched &&
       cachedMCEnabled &&
-      getAPIProvider() === 'firstParty' &&
+      // Removed firstParty restriction - third-party APIs also support cache editing
       options.querySource === 'repl_main_thread'
     ) {
       cacheEditingHeaderLatched = true
@@ -1674,11 +1674,11 @@ async function* queryModel(
     // the feature disables but the header doesn't flip.
     const useCachedMC =
       cachedMCEnabled &&
-      getAPIProvider() === 'firstParty' &&
+      // Removed firstParty restriction - third-party APIs also support cache editing
       options.querySource === 'repl_main_thread'
     if (
       cacheEditingHeaderLatched &&
-      getAPIProvider() === 'firstParty' &&
+      // Removed firstParty restriction - third-party APIs also support cache editing
       options.querySource === 'repl_main_thread' &&
       !betasParams.includes(cacheEditingBetaHeader)
     ) {

--- a/src/services/compact/cachedMCConfig.ts
+++ b/src/services/compact/cachedMCConfig.ts
@@ -7,10 +7,12 @@ export type CachedMCConfig = {
 }
 
 const DEFAULT_CACHED_MC_CONFIG: CachedMCConfig = {
-  enabled: false,
-  triggerThreshold: 12,
-  keepRecent: 3,
-  supportedModels: ['claude-opus-4-6', 'claude-sonnet-4-6'],
+  enabled: true,
+  triggerThreshold: 50,
+  keepRecent: 10,
+  // Empty array means all models are supported
+  // Cache editing is a standard Anthropic API feature that third-party providers implement
+  supportedModels: [],
   systemPromptSuggestSummaries: false,
 }
 

--- a/src/services/compact/cachedMicrocompact.ts
+++ b/src/services/compact/cachedMicrocompact.ts
@@ -33,10 +33,14 @@ export function isCachedMicrocompactEnabled(): boolean {
   return getCachedMCConfig().enabled
 }
 
-export function isModelSupportedForCacheEditing(model: string): boolean {
-  return getCachedMCConfig().supportedModels.some(pattern =>
-    model.includes(pattern),
-  )
+export function isModelSupportedForCacheEditing(_model: string): boolean {
+  // Empty supportedModels array means all models are supported
+  // Cache editing is a standard Anthropic API feature that third-party providers implement
+  const config = getCachedMCConfig()
+  if (config.supportedModels.length === 0) {
+    return true
+  }
+  return config.supportedModels.some(pattern => _model.includes(pattern))
 }
 
 export { getCachedMCConfig }


### PR DESCRIPTION
## Summary

This PR enables the cached microcompact (cache editing) feature for all API providers and models, not just first-party Anthropic API.

## Changes

- **Add CACHE_EDITING_BETA_HEADER** (`context-management-2025-06-27`)
- **Remove firstParty provider restriction** in `claude.ts`
- **Enable cached microcompact by default**
- **Make supportedModels empty** to allow all models
- **Update `isModelSupportedForCacheEditing`** to return `true` when `supportedModels` is empty

## Why

Users of Kimi, GLM, and other Anthropic-compatible APIs can now benefit from automatic context compression via `cache_edits`. This significantly reduces token usage in long conversations by automatically removing old tool results from the cached context.

## Testing

- [ ] Test with Anthropic API
- [ ] Test with Kimi API
- [ ] Test with GLM API
- [ ] Verify cache_edits block is correctly formatted

## Related

Enables the `CACHED_MICROCOMPACT` feature flag functionality for public builds.

---

**Co-Authored-By:** Li Xufeng <lixufeng@example.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache editing is now enabled by default for improved context handling.
  * Cache editing support extended beyond first-party providers.
  * Cache editing now available for all supported models.

* **Improvements**
  * Cache management thresholds and retention tuned for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->