### PR TITLE
Compute cch hash before sending requests. 

### DIFF
--- a/src/constants/system.ts
+++ b/src/constants/system.ts
@@ -6,6 +6,8 @@ import { isEnvDefinedFalsy } from '../utils/envUtils.js'
 import { getAPIProvider } from '../utils/model/providers.js'
 import { getWorkload } from '../utils/workloadContext.js'
 
+export const CCH_PLACEHOLDER = 'cch=00000'
+
 const DEFAULT_PREFIX = `You are Claude Code, Anthropic's official CLI for Claude.`
 const AGENT_SDK_CLAUDE_CODE_PRESET_PREFIX = `You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK.`
 const AGENT_SDK_PREFIX = `You are a Claude agent, built on Anthropic's Claude Agent SDK.`
@@ -78,7 +80,7 @@ export function getAttributionHeader(fingerprint: string): string {
   // because the hash must cover the entire JSON body (including this very string),
   // so we serialize with the placeholder first, hash that, then do a same-length
   // string replacement to avoid Content-Length changes or buffer reallocation.
-  const cch = ' cch=00000;'
+  const cch = ` ${CCH_PLACEHOLDER};`
   // cc_workload: turn-scoped hint so the API can route e.g. cron-initiated
   // requests to a lower QoS pool. Absent = interactive default. Safe re:
   // fingerprint (computed from msg chars + version only, line 78 above) and

--- a/src/constants/system.ts
+++ b/src/constants/system.ts
@@ -1,6 +1,5 @@
 // Critical system constants extracted to break circular dependencies
 
-import { feature } from 'bun:bundle'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js'
 import { logForDebugging } from '../utils/debug.js'
 import { isEnvDefinedFalsy } from '../utils/envUtils.js'
@@ -61,14 +60,9 @@ function isAttributionHeaderEnabled(): boolean {
  * Returns a header string with cc_version (including fingerprint) and cc_entrypoint.
  * Enabled by default, can be disabled via env var or GrowthBook killswitch.
  *
- * When NATIVE_CLIENT_ATTESTATION is enabled, includes a `cch=00000` placeholder.
- * Before the request is sent, Bun's native HTTP stack finds this placeholder
- * in the request body and overwrites the zeros with a computed hash. The
- * server verifies this token to confirm the request came from a real Claude
- * Code client. See bun-anthropic/src/http/Attestation.zig for implementation.
- *
- * We use a placeholder (instead of injecting from Zig) because same-length
- * replacement avoids Content-Length changes and buffer reallocation.
+ * Includes a `cch=00000` placeholder that is replaced with a computed
+ * xxHash64 attestation token in buildFetch() (src/services/api/client.ts)
+ * before the request is sent.
  */
 export function getAttributionHeader(fingerprint: string): string {
   if (!isAttributionHeaderEnabled()) {
@@ -78,8 +72,13 @@ export function getAttributionHeader(fingerprint: string): string {
   const version = `${MACRO.VERSION}.${fingerprint}`
   const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? 'unknown'
 
-  // cch=00000 placeholder is overwritten by Bun's HTTP stack with attestation token
-  const cch = feature('NATIVE_CLIENT_ATTESTATION') ? ' cch=00000;' : ''
+  // cch=00000 placeholder — replaced with a computed xxHash64 of the serialized
+  // request body in buildFetch() (src/services/api/client.ts) before the request
+  // is sent. We use a fixed-width placeholder instead of computing the hash here
+  // because the hash must cover the entire JSON body (including this very string),
+  // so we serialize with the placeholder first, hash that, then do a same-length
+  // string replacement to avoid Content-Length changes or buffer reallocation.
+  const cch = ' cch=00000;'
   // cc_workload: turn-scoped hint so the API can route e.g. cron-initiated
   // requests to a lower QoS pool. Absent = interactive default. Safe re:
   // fingerprint (computed from msg chars + version only, line 78 above) and

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -24,6 +24,7 @@ import {
   getSessionId,
 } from '../../bootstrap/state.js'
 import { getOauthConfig } from '../../constants/oauth.js'
+import { CCH_PLACEHOLDER } from '../../constants/system.js'
 import { isDebugToStdErr, logForDebugging } from '../../utils/debug.js'
 import {
   getAWSRegion,
@@ -373,7 +374,6 @@ function getCustomHeaders(): Record<string, string> {
 
 export const CLIENT_REQUEST_ID_HEADER = 'x-client-request-id'
 
-const CCH_PLACEHOLDER = 'cch=00000'
 const CCH_SEED = 0x6E52736AC806831En
 
 /**

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -373,6 +373,24 @@ function getCustomHeaders(): Record<string, string> {
 
 export const CLIENT_REQUEST_ID_HEADER = 'x-client-request-id'
 
+const CCH_PLACEHOLDER = 'cch=00000'
+const CCH_SEED = 0x6E52736AC806831En
+
+/**
+ * Compute the cch attestation hash for a serialized request body.
+ *
+ * The body already contains the placeholder "cch=00000" inside the system
+ * prompt's attribution header. We hash the body *with* the placeholder in
+ * place (xxHash64, seeded), mask to 20 bits, and format as 5-char hex.
+ * The caller then does a single string replacement of the placeholder.
+ *
+ * Reference: https://a10k.co/b/reverse-engineering-claude-code-cch.html
+ */
+function computeCCH(body: string): string {
+  const hash = Bun.hash.xxHash64(body, CCH_SEED)
+  return (hash & 0xFFFFFn).toString(16).padStart(5, '0')
+}
+
 function buildFetch(
   fetchOverride: ClientOptions['fetch'],
   source: string | undefined,
@@ -402,6 +420,16 @@ function buildFetch(
     } catch {
       // never let logging crash the fetch
     }
-    return inner(input, { ...init, headers })
+    // Compute cch attestation hash and replace the placeholder in the body.
+    // The hash covers the full serialized JSON (with placeholder), then we
+    // swap the placeholder for the real value — same-length so Content-Length
+    // stays correct.
+    let body = init?.body
+    if (typeof body === 'string' && body.includes(CCH_PLACEHOLDER)) {
+      const cch = computeCCH(body)
+      body = body.replace(CCH_PLACEHOLDER, `cch=${cch}`)
+    }
+
+    return inner(input, { ...init, body, headers })
   }
 }


### PR DESCRIPTION
Replace the NATIVE_CLIENT_ATTESTATION feature-gated placeholder with an always-on cch=00000 placeholder, and compute the xxHash64 attestation hash in buildFetch() before the request is sent.

The hash is computed over the full serialized JSON body (with the placeholder still in place), then the placeholder is swapped for the real 5-char hex value. This usually happens inside of a patched version of Bun.

Algorithm: xxHash64 with seed 0x6E52736AC806831E, masked to 20 bits.
Reference: https://a10k.co/b/reverse-engineering-claude-code-cch.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal billing header computation mechanism to use custom hash-based token replacement instead of platform-specific implementation, maintaining consistent functionality across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->