### PR TITLE
fix: remove duplicate isCodexSubscriber causing provider lock-in

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1627,26 +1627,12 @@ export function isClaudeAISubscriber(): boolean {
 }
 
 export function isCodexSubscriber(): boolean {
-  // Check if we're using OpenAI API via environment variable
-  if (getAPIProvider() === 'openai') {
-    return true
+  // Only treat as Codex subscriber when explicitly using OpenAI provider
+  if (getAPIProvider() !== 'openai') {
+    return false
   }
 
-  // Check if we have OpenAI OAuth tokens
-  const config = getGlobalConfig()
-  const openaiTokens = config?.openaiOauthTokens
-  if (openaiTokens?.access_token && openaiTokens?.scopes?.includes('codex')) {
-    return true
-  }
-
-  return false
-}
-
-/**
- * Check if the user is authenticated via OpenAI Codex OAuth.
- * Returns true when a valid Codex access token is present in the config.
- */
-export function isCodexSubscriber(): boolean {
+  // Verify we actually have valid Codex tokens
   const tokens = getCodexOAuthTokens()
   return !!tokens?.accessToken
 }


### PR DESCRIPTION
## Summary
- The Codex PR introduced a **duplicate `isCodexSubscriber()` function** that silently overwrote the first definition
- The second definition only checked for token existence, ignoring the active provider — once a user authenticated with Codex, **all requests were permanently routed to the Codex endpoint** regardless of model/provider selection
- Merged both functions into one that requires the provider to be explicitly set to `openai` before returning `true`

## Test plan
- [ ] Authenticate with Codex, then switch model back to Opus — verify requests go to `api.anthropic.com`, not `chatgpt.com/backend-api/codex`
- [ ] Verify Codex still works when `CLAUDE_CODE_USE_OPENAI=1` is set and tokens are present
- [ ] Verify normal Anthropic auth flow is unaffected when no Codex tokens exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the authentication logic for Codex subscription verification to use a more streamlined, token-based approach.
  * Removed legacy code related to outdated subscription detection methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->