### PR TITLE
Refactor directory creation logic in build script

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -119,7 +119,10 @@ const outfile = compile
 const buildTime = new Date().toISOString()
 const version = dev ? getDevVersion(pkg.version) : pkg.version
 
-mkdirSync(dirname(outfile), { recursive: true })
+const outDir = dirname(outfile)
+if (outDir !== '.') {
+  mkdirSync(outDir, { recursive: true })
+}
 
 const externals = [
   '@ant/*',


### PR DESCRIPTION
Fix build crash on windows devices due to `.` dir name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build process to create output directories more efficiently, only when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->