### PR TITLE
add local buddy and local ultraplan flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Use Anthropic's first-party API directly.
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` |
 | Claude Haiku 4.5 | `claude-haiku-4-5` |
 
-### OpenAI Codex
+### OpenAI Codex / OpenAI-Compatible Mirrors
 
-Use OpenAI's Codex models for code generation. Requires a Codex subscription.
+Use Codex-compatible `responses` backends, including OpenAI OAuth and third-party mirrors such as SoruxGPT.
 
 | Model | ID |
 |---|---|
@@ -99,9 +99,31 @@ Use OpenAI's Codex models for code generation. Requires a Codex subscription.
 | GPT-5.4 | `gpt-5.4` |
 | GPT-5.4 Mini | `gpt-5.4-mini` |
 
+OpenAI OAuth:
+
 ```bash
 export CLAUDE_CODE_USE_OPENAI=1
 free-code
+```
+
+OpenAI-compatible API key + custom base URL:
+
+```bash
+export CLAUDE_CODE_USE_OPENAI=1
+export OPENAI_API_KEY="your-access-token"
+export OPENAI_BASE_URL="https://your-provider.example.com/codex"
+free-code
+```
+
+`OPENAI_BASE_URL` may be either the provider's Codex base (for example `.../codex`) or the full `.../responses` URL. `free-code` will normalize both.
+
+#### SoruxGPT example
+
+```powershell
+$env:CLAUDE_CODE_USE_OPENAI="1"
+$env:OPENAI_API_KEY="你的 SoruxGPT Access Token"
+$env:OPENAI_BASE_URL="https://chat.soruxgpt.com/codex"
+.\cli.exe --model gpt-5.3-codex
 ```
 
 ### AWS Bedrock
@@ -152,7 +174,7 @@ Supports custom deployment IDs as model names.
 | Provider | Env Variable | Auth Method |
 |---|---|---|
 | Anthropic (default) | -- | `ANTHROPIC_API_KEY` or OAuth |
-| OpenAI Codex | `CLAUDE_CODE_USE_OPENAI=1` | OAuth via OpenAI |
+| OpenAI Codex / Mirrors | `CLAUDE_CODE_USE_OPENAI=1` | OpenAI OAuth or `OPENAI_API_KEY` |
 | AWS Bedrock | `CLAUDE_CODE_USE_BEDROCK=1` | AWS credentials |
 | Google Vertex AI | `CLAUDE_CODE_USE_VERTEX=1` | `gcloud` ADC |
 | Anthropic Foundry | `CLAUDE_CODE_USE_FOUNDRY=1` | `ANTHROPIC_FOUNDRY_API_KEY` |
@@ -236,6 +258,11 @@ bun run dev
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Custom Haiku model ID |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token via env |
 | `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` | API key helper cache TTL |
+| `CLAUDE_CODE_USE_OPENAI` | Enable Codex/OpenAI-compatible provider |
+| `OPENAI_API_KEY` | API key or mirror access token for Codex provider |
+| `OPENAI_BASE_URL` | Custom Codex base URL, e.g. `https://chat.soruxgpt.com/codex` |
+| `CLAUDE_CODE_OPENAI_API_KEY` | Alias for `OPENAI_API_KEY` |
+| `CLAUDE_CODE_OPENAI_BASE_URL` | Alias for `OPENAI_BASE_URL` |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:dev:full": "bun run ./scripts/build.ts --dev --feature-set=dev-full",
     "compile": "bun run ./scripts/build.ts --compile",
     "dev": "bun run ./src/entrypoints/cli.tsx",
-    "update:sorux": "powershell -ExecutionPolicy Bypass -File ./scripts/update-sorux.ps1 -Build"
+    "update:sorux": "bun run ./scripts/update-sorux.ts --build"
   },
   "dependencies": {
     "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build:dev": "bun run ./scripts/build.ts --dev",
     "build:dev:full": "bun run ./scripts/build.ts --dev --feature-set=dev-full",
     "compile": "bun run ./scripts/build.ts --compile",
-    "dev": "bun run ./src/entrypoints/cli.tsx"
+    "dev": "bun run ./src/entrypoints/cli.tsx",
+    "update:sorux": "powershell -ExecutionPolicy Bypass -File ./scripts/update-sorux.ps1 -Build"
   },
   "dependencies": {
     "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -80,7 +80,7 @@ function getVersionChangelog(): string {
   )
 }
 
-const defaultFeatures = ['VOICE_MODE', 'BUDDY']
+const defaultFeatures = ['VOICE_MODE', 'BUDDY', 'ULTRAPLAN']
 const featureSet = new Set(defaultFeatures)
 for (let i = 0; i < args.length; i += 1) {
   const arg = args[i]

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -16,6 +16,7 @@ const fullExperimentalFeatures = [
   'AGENT_TRIGGERS_REMOTE',
   'AWAY_SUMMARY',
   'BASH_CLASSIFIER',
+  'BUDDY',
   'BRIDGE_MODE',
   'BUILTIN_EXPLORE_PLAN_AGENTS',
   'CACHED_MICROCOMPACT',
@@ -79,7 +80,7 @@ function getVersionChangelog(): string {
   )
 }
 
-const defaultFeatures = ['VOICE_MODE']
+const defaultFeatures = ['VOICE_MODE', 'BUDDY']
 const featureSet = new Set(defaultFeatures)
 for (let i = 0; i < args.length; i += 1) {
   const arg = args[i]

--- a/scripts/update-sorux.ps1
+++ b/scripts/update-sorux.ps1
@@ -1,0 +1,71 @@
+param(
+  [switch]$Build,
+  [string]$CommandName = 'sorux',
+  [string]$WrapperPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$cliPath = Join-Path $repoRoot 'cli.exe'
+
+if ($Build) {
+  Write-Host "Building latest cli.exe with default features from $repoRoot ..." -ForegroundColor Cyan
+  Push-Location $repoRoot
+  try {
+    bun run .\scripts\build.ts
+  } finally {
+    Pop-Location
+  }
+}
+
+if (-not (Test-Path -LiteralPath $cliPath)) {
+  throw "cli.exe not found at $cliPath. Build first."
+}
+
+if ([string]::IsNullOrWhiteSpace($WrapperPath)) {
+  $command = Get-Command $CommandName -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($command) {
+    $WrapperPath = $command.Path
+  } else {
+    $WrapperPath = Join-Path $HOME ".local\bin\$CommandName.cmd"
+  }
+}
+
+$wrapperDir = Split-Path -Parent $WrapperPath
+if (-not (Test-Path -LiteralPath $wrapperDir)) {
+  New-Item -ItemType Directory -Path $wrapperDir -Force | Out-Null
+}
+
+if (Test-Path -LiteralPath $WrapperPath) {
+  $content = Get-Content -LiteralPath $WrapperPath -Raw
+  if ($content -match 'set "FREECODE_ROOT=') {
+    $updated = [regex]::Replace(
+      $content,
+      'set "FREECODE_ROOT=.*?"',
+      { param($match) "set `"FREECODE_ROOT=$repoRoot`"" }
+    )
+    if ($updated -ne $content) {
+      Set-Content -LiteralPath $WrapperPath -Value $updated -Encoding ascii
+    }
+  }
+} else {
+  $wrapper = @"
+@echo off
+setlocal
+set "FREECODE_ROOT=$repoRoot"
+cd /d "%FREECODE_ROOT%"
+if exist ".\cli.exe" (
+  ".\cli.exe" %*
+  exit /b %errorlevel%
+) else (
+  echo cli.exe not found under %FREECODE_ROOT%
+  exit /b 1
+)
+"@
+  Set-Content -LiteralPath $WrapperPath -Value $wrapper -Encoding ascii
+}
+
+Write-Host "sorux wrapper: $WrapperPath" -ForegroundColor Green
+Write-Host "repo root    : $repoRoot" -ForegroundColor Green
+Write-Host "cli.exe      : $cliPath" -ForegroundColor Green

--- a/scripts/update-sorux.ps1
+++ b/scripts/update-sorux.ps1
@@ -6,66 +6,16 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
-$cliPath = Join-Path $repoRoot 'cli.exe'
-
+$args = @('run', (Join-Path $PSScriptRoot 'update-sorux.ts'))
 if ($Build) {
-  Write-Host "Building latest cli.exe with default features from $repoRoot ..." -ForegroundColor Cyan
-  Push-Location $repoRoot
-  try {
-    bun run .\scripts\build.ts
-  } finally {
-    Pop-Location
-  }
+  $args += '--build'
+}
+if ($CommandName -and $CommandName -ne 'sorux') {
+  $args += @('--command-name', $CommandName)
+}
+if ($WrapperPath) {
+  $args += @('--wrapper-path', $WrapperPath)
 }
 
-if (-not (Test-Path -LiteralPath $cliPath)) {
-  throw "cli.exe not found at $cliPath. Build first."
-}
-
-if ([string]::IsNullOrWhiteSpace($WrapperPath)) {
-  $command = Get-Command $CommandName -ErrorAction SilentlyContinue | Select-Object -First 1
-  if ($command) {
-    $WrapperPath = $command.Path
-  } else {
-    $WrapperPath = Join-Path $HOME ".local\bin\$CommandName.cmd"
-  }
-}
-
-$wrapperDir = Split-Path -Parent $WrapperPath
-if (-not (Test-Path -LiteralPath $wrapperDir)) {
-  New-Item -ItemType Directory -Path $wrapperDir -Force | Out-Null
-}
-
-if (Test-Path -LiteralPath $WrapperPath) {
-  $content = Get-Content -LiteralPath $WrapperPath -Raw
-  if ($content -match 'set "FREECODE_ROOT=') {
-    $updated = [regex]::Replace(
-      $content,
-      'set "FREECODE_ROOT=.*?"',
-      { param($match) "set `"FREECODE_ROOT=$repoRoot`"" }
-    )
-    if ($updated -ne $content) {
-      Set-Content -LiteralPath $WrapperPath -Value $updated -Encoding ascii
-    }
-  }
-} else {
-  $wrapper = @"
-@echo off
-setlocal
-set "FREECODE_ROOT=$repoRoot"
-cd /d "%FREECODE_ROOT%"
-if exist ".\cli.exe" (
-  ".\cli.exe" %*
-  exit /b %errorlevel%
-) else (
-  echo cli.exe not found under %FREECODE_ROOT%
-  exit /b 1
-)
-"@
-  Set-Content -LiteralPath $WrapperPath -Value $wrapper -Encoding ascii
-}
-
-Write-Host "sorux wrapper: $WrapperPath" -ForegroundColor Green
-Write-Host "repo root    : $repoRoot" -ForegroundColor Green
-Write-Host "cli.exe      : $cliPath" -ForegroundColor Green
+& bun @args
+exit $LASTEXITCODE

--- a/scripts/update-sorux.ts
+++ b/scripts/update-sorux.ts
@@ -1,0 +1,87 @@
+import { existsSync } from 'fs'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+
+import {
+  renderSoruxWrapper,
+  updateSoruxWrapperContent,
+} from '../src/utils/soruxWrapper.js'
+
+function getArgValue(flag: string): string | undefined {
+  const index = process.argv.findIndex(arg => arg === flag)
+  if (index === -1) return undefined
+  return process.argv[index + 1]
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag)
+}
+
+function runCommand(cmd: string[]): { stdout: string; code: number } {
+  const proc = Bun.spawnSync({
+    cmd,
+    cwd: process.cwd(),
+    stdout: 'pipe',
+    stderr: 'inherit',
+  })
+  return {
+    stdout: new TextDecoder().decode(proc.stdout).trim(),
+    code: proc.exitCode ?? 1,
+  }
+}
+
+function findWrapperPath(commandName: string): string {
+  if (process.platform === 'win32') {
+    const found = runCommand(['where.exe', commandName])
+    if (found.code === 0) {
+      const first = found.stdout.split(/\r?\n/).find(Boolean)
+      if (first) return first
+    }
+    return join(process.env.USERPROFILE ?? process.env.HOME ?? '.', '.local', 'bin', `${commandName}.cmd`)
+  }
+
+  const found = runCommand(['which', commandName])
+  if (found.code === 0 && found.stdout) return found.stdout.split(/\r?\n/)[0]!
+  return join(process.env.HOME ?? '.', '.local', 'bin', commandName)
+}
+
+async function main(): Promise<void> {
+  const build = hasFlag('--build')
+  const commandName = getArgValue('--command-name') ?? 'sorux'
+  const wrapperPath = getArgValue('--wrapper-path') ?? findWrapperPath(commandName)
+  const repoRoot = process.cwd()
+  const cliPath = join(repoRoot, 'cli.exe')
+
+  if (build) {
+    console.log(`Building latest cli.exe with default features from ${repoRoot} ...`)
+    const result = Bun.spawnSync({
+      cmd: ['bun', 'run', './scripts/build.ts'],
+      cwd: repoRoot,
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    if ((result.exitCode ?? 1) !== 0) process.exit(result.exitCode ?? 1)
+  }
+
+  if (!existsSync(cliPath)) {
+    throw new Error(`cli.exe not found at ${cliPath}. Build first.`)
+  }
+
+  await mkdir(dirname(wrapperPath), { recursive: true })
+
+  if (existsSync(wrapperPath)) {
+    const content = await readFile(wrapperPath, 'utf8')
+    const updated = updateSoruxWrapperContent(content, repoRoot)
+    if (updated !== content) {
+      await writeFile(wrapperPath, updated, 'ascii')
+    }
+  } else {
+    await writeFile(wrapperPath, renderSoruxWrapper(repoRoot), 'ascii')
+  }
+
+  console.log(`sorux wrapper: ${wrapperPath}`)
+  console.log(`repo root    : ${repoRoot}`)
+  console.log(`cli.exe      : ${cliPath}`)
+}
+
+await main()

--- a/src/buddy/card.ts
+++ b/src/buddy/card.ts
@@ -1,0 +1,81 @@
+import { renderSprite } from './sprites.js'
+import { RARITY_STARS, STAT_NAMES, type Companion } from './types.js'
+
+function wrap(text: string, width: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let current = ''
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word
+    if (next.length > width && current) {
+      lines.push(current)
+      current = word
+    } else {
+      current = next
+    }
+  }
+
+  if (current) lines.push(current)
+  return lines
+}
+
+// Inspired by the MIT-licensed save-buddy card layout, adapted to freecode's
+// built-in companion model and local-only state.
+export function renderCompanionCard(
+  companion: Companion,
+  lastReaction?: string,
+): string {
+  const width = 38
+  const lines: string[] = []
+  const stars = RARITY_STARS[companion.rarity] ?? ''
+  const rarity = companion.rarity.toUpperCase()
+  const species = companion.species.toUpperCase()
+  const sprite = renderSprite(companion, 0)
+
+  lines.push(`╭${'─'.repeat(width)}╮`)
+  lines.push(`│${' '.repeat(width)}│`)
+
+  const left = `  ${stars} ${rarity}`.trimEnd()
+  const right = `${species}  `
+  lines.push(
+    `│${left}${' '.repeat(Math.max(0, width - left.length - right.length))}${right}│`,
+  )
+  lines.push(`│${' '.repeat(width)}│`)
+
+  for (const spriteLine of sprite) {
+    const padded = `    ${spriteLine.trimEnd()}`
+    lines.push(`│${padded.padEnd(width)}│`)
+  }
+
+  lines.push(`│${' '.repeat(width)}│`)
+  lines.push(`│${`  ${companion.name}`.padEnd(width)}│`)
+  lines.push(`│${' '.repeat(width)}│`)
+
+  for (const line of wrap(`"${companion.personality}"`, width - 4)) {
+    lines.push(`│${`  ${line}`.padEnd(width)}│`)
+  }
+
+  lines.push(`│${' '.repeat(width)}│`)
+
+  for (const statName of STAT_NAMES) {
+    const value = Number(companion.stats[statName] || 0)
+    const filled = Math.round(value / 10)
+    const bar = `${'█'.repeat(filled)}${'░'.repeat(Math.max(0, 10 - filled))}`
+    const content = `  ${statName.padEnd(10)} ${bar}${String(value).padStart(3)}`
+    lines.push(`│${content.padEnd(width)}│`)
+  }
+
+  if (lastReaction) {
+    lines.push(`│${' '.repeat(width)}│`)
+    lines.push(`│${'  last said'.padEnd(width)}│`)
+    for (const line of wrap(`"${lastReaction}"`, width - 6)) {
+      lines.push(`│${`  ${line}`.padEnd(width)}│`)
+    }
+  }
+
+  lines.push(`│${' '.repeat(width)}│`)
+  lines.push(`╰${'─'.repeat(width)}╯`)
+  return lines.join('\n')
+}
+

--- a/src/buddy/companion.ts
+++ b/src/buddy/companion.ts
@@ -1,4 +1,4 @@
-import { getGlobalConfig } from '../utils/config.js'
+import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js'
 import {
   type Companion,
   type CompanionBones,
@@ -88,6 +88,58 @@ export type Roll = {
   inspirationSeed: number
 }
 
+const NAME_PREFIXES = [
+  'Byte',
+  'Mochi',
+  'Pico',
+  'Nova',
+  'Pixel',
+  'Echo',
+  'Biscuit',
+  'Tango',
+  'Pebble',
+  'Cosmo',
+] as const
+
+const NAME_SUFFIXES = [
+  'duck',
+  'loop',
+  'spark',
+  'patch',
+  'bean',
+  'zip',
+  'dot',
+  'whisk',
+  'bot',
+  'moss',
+] as const
+
+const PERSONALITY_OPENERS = [
+  'quietly judges messy diffs',
+  'loves clean fixes and suspicious logs',
+  'hovers near broken builds waiting to comment',
+  'treats every warning as a personal invitation',
+  'prefers sharp plans over heroic rewrites',
+  'keeps morale up with dry side remarks',
+] as const
+
+const PERSONALITY_CLOSERS = [
+  'but turns soft when you ship something solid.',
+  'and gets restless when you ignore obvious clues.',
+  'while secretly rooting for the smallest correct fix.',
+  'and insists that debugging is a form of affection.',
+  'yet still celebrates every green checkmark.',
+  'and somehow always notices the real blocker first.',
+] as const
+
+const PET_REACTIONS = [
+  'I was already helping, but this is appreciated.',
+  'Acceptable. Continue the good work.',
+  'That almost offsets the last risky edit.',
+  'Morale increased. Standards unchanged.',
+  'I will allow one celebratory moment.',
+] as const
+
 function rollFrom(rng: () => number): Roll {
   const rarity = rollRarity(rng)
   const bones: CompanionBones = {
@@ -119,6 +171,45 @@ export function rollWithSeed(seed: string): Roll {
 export function companionUserId(): string {
   const config = getGlobalConfig()
   return config.oauthAccount?.accountUuid ?? config.userID ?? 'anon'
+}
+
+function soulFromRoll(
+  userId: string,
+  bones: CompanionBones,
+  inspirationSeed: number,
+): import('./types.js').StoredCompanion {
+  const rng = mulberry32(hashString(`${userId}:${inspirationSeed}:soul`))
+  const prefix = pick(rng, NAME_PREFIXES)
+  const suffix = pick(rng, NAME_SUFFIXES)
+  const topStat = [...STAT_NAMES].sort((a, b) => bones.stats[b] - bones.stats[a])[0]
+  const opener = pick(rng, PERSONALITY_OPENERS)
+  const closer = pick(rng, PERSONALITY_CLOSERS)
+
+  return {
+    name: `${prefix}${suffix}`,
+    personality: `${opener}, with a bias toward ${topStat}. ${closer}`,
+    hatchedAt: Date.now(),
+  }
+}
+
+export function ensureCompanion(): Companion {
+  const existing = getCompanion()
+  if (existing) return existing
+
+  const userId = companionUserId()
+  const { bones, inspirationSeed } = roll(userId)
+  const soul = soulFromRoll(userId, bones, inspirationSeed)
+  saveGlobalConfig(current =>
+    current.companion ? current : { ...current, companion: soul },
+  )
+  return { ...soul, ...bones }
+}
+
+export function getPetReaction(companion: Companion): string {
+  const rng = mulberry32(
+    hashString(`${companion.name}:${Date.now() >> 13}:pet-reaction`),
+  )
+  return pick(rng, PET_REACTIONS)
 }
 
 // Regenerate bones from userId, merge with stored soul. Bones never persist

--- a/src/buddy/observer.ts
+++ b/src/buddy/observer.ts
@@ -1,0 +1,142 @@
+import type { Message } from '../types/message.js'
+import { getGlobalConfig } from '../utils/config.js'
+import { getCompanion, rollWithSeed } from './companion.js'
+
+const TURN_COOLDOWN_MS = 30_000
+let lastReactionAt = 0
+let lastReactionKey = ''
+
+const SUCCESS_REACTIONS = [
+  'That looked cleaner than I expected.',
+  'Acceptable progress. Keep the momentum.',
+  'Green lights suit this repo.',
+  'A small correct step is still a win.',
+] as const
+
+const FAILURE_REACTIONS = [
+  'There it is. The real problem just introduced itself.',
+  'Good. Now we have a concrete failure to work with.',
+  'Messy, but informative.',
+  'At least the bug stopped hiding.',
+] as const
+
+const ADDRESS_REACTIONS = [
+  'I am listening.',
+  'Proceed. Prefer specifics.',
+  'I noticed.',
+  'You have my attention.',
+] as const
+
+const IDLE_REACTIONS = [
+  'I am still watching the edges.',
+  'This feels close to the actual fix.',
+  'Plan first. Then cut cleanly.',
+  'There is usually one smaller move that works.',
+] as const
+
+function getMessageText(message: Message): string {
+  if (message.type === 'user' || message.type === 'assistant') {
+    const content = (message as { message?: { content?: unknown[] } }).message
+      ?.content
+    if (!Array.isArray(content)) return ''
+    return content
+      .map(block =>
+        typeof block === 'object' &&
+        block !== null &&
+        'text' in block &&
+        typeof (block as { text?: unknown }).text === 'string'
+          ? (block as { text: string }).text
+          : '',
+      )
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  if (message.type === 'system') {
+    return (message as { content?: string }).content ?? ''
+  }
+
+  return ''
+}
+
+function pickDeterministic<T>(seed: string, values: readonly T[]): T {
+  return values[rollWithSeed(seed).inspirationSeed % values.length]!
+}
+
+function classifyRecentMessages(
+  messages: Message[],
+  companionName: string,
+): { key: string; reaction?: string; bypassCooldown?: boolean } {
+  const recent = messages.slice(-8)
+  const transcript = recent.map(getMessageText).join('\n').trim()
+  if (!transcript) return { key: '' }
+
+  const lower = transcript.toLowerCase()
+  const nameLower = companionName.toLowerCase()
+  const seedBase = `${nameLower}:${transcript.slice(-300)}`
+
+  if (
+    lower.includes(nameLower) ||
+    lower.includes('/buddy pet') ||
+    lower.includes('/buddy ')
+  ) {
+    return {
+      key: `address:${seedBase}`,
+      reaction: pickDeterministic(`address:${seedBase}`, ADDRESS_REACTIONS),
+      bypassCooldown: true,
+    }
+  }
+
+  if (
+    /\b(failed|error|exception|traceback|not defined|access denied|cannot|unable to|exit code [1-9]|test failed)\b/i.test(
+      transcript,
+    )
+  ) {
+    return {
+      key: `failure:${seedBase}`,
+      reaction: pickDeterministic(`failure:${seedBase}`, FAILURE_REACTIONS),
+      bypassCooldown: true,
+    }
+  }
+
+  if (
+    /\b(completed|success|fixed|done|built|compiled|created|updated|wrote|passed)\b/i.test(
+      transcript,
+    )
+  ) {
+    return {
+      key: `success:${seedBase}`,
+      reaction: pickDeterministic(`success:${seedBase}`, SUCCESS_REACTIONS),
+    }
+  }
+
+  const idleRoll = rollWithSeed(`idle:${seedBase}`).inspirationSeed % 5
+  if (idleRoll === 0) {
+    return {
+      key: `idle:${seedBase}`,
+      reaction: pickDeterministic(`idle:${seedBase}`, IDLE_REACTIONS),
+    }
+  }
+
+  return { key: `none:${seedBase}` }
+}
+
+export async function fireCompanionObserver(
+  messages: Message[],
+  onReaction: (reaction: string) => void,
+): Promise<void> {
+  const companion = getCompanion()
+  if (!companion || getGlobalConfig().companionMuted) return
+
+  const result = classifyRecentMessages(messages, companion.name)
+  if (!result.reaction || !result.key) return
+  if (result.key === lastReactionKey) return
+
+  const now = Date.now()
+  if (!result.bypassCooldown && now - lastReactionAt < TURN_COOLDOWN_MS) return
+
+  lastReactionAt = now
+  lastReactionKey = result.key
+  onReaction(result.reaction)
+}
+

--- a/src/commands/buddy/buddy.ts
+++ b/src/commands/buddy/buddy.ts
@@ -1,0 +1,103 @@
+import type { LocalCommandCall } from '../../types/command.js'
+import { renderCompanionCard } from '../../buddy/card.js'
+import {
+  ensureCompanion,
+  getCompanion,
+  getPetReaction,
+} from '../../buddy/companion.js'
+import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
+
+function formatStatsJson(): string {
+  const companion = getCompanion()
+  if (!companion) return '{}'
+  return JSON.stringify(
+    {
+      name: companion.name,
+      personality: companion.personality,
+      rarity: companion.rarity,
+      species: companion.species,
+      eye: companion.eye,
+      hat: companion.hat,
+      shiny: companion.shiny,
+      stats: companion.stats,
+    },
+    null,
+    2,
+  )
+}
+
+export const call: LocalCommandCall = async (args, context) => {
+  const subcommand = (args || '').trim().toLowerCase()
+
+  if (subcommand === 'mute' || subcommand === 'off') {
+    saveGlobalConfig(current =>
+      current.companionMuted
+        ? current
+        : { ...current, companionMuted: true },
+    )
+    context.setAppState(prev =>
+      prev.companionReaction === undefined
+        ? prev
+        : { ...prev, companionReaction: undefined },
+    )
+    return {
+      type: 'text',
+      value: 'Buddy muted. The companion stays hatched but stops reacting.',
+    }
+  }
+
+  if (subcommand === 'unmute' || subcommand === 'on') {
+    saveGlobalConfig(current =>
+      current.companionMuted === false
+        ? current
+        : { ...current, companionMuted: false },
+    )
+    return {
+      type: 'text',
+      value: 'Buddy unmuted. The companion can react again.',
+    }
+  }
+
+  const companion = ensureCompanion()
+
+  if (subcommand === 'pet') {
+    const reaction = getPetReaction(companion)
+    context.setAppState(prev => ({
+      ...prev,
+      companionPetAt: Date.now(),
+      companionReaction: reaction,
+    }))
+    return {
+      type: 'text',
+      value: `${companion.name} leans in. "${reaction}"`,
+    }
+  }
+
+  if (subcommand === 'stats') {
+    return { type: 'text', value: formatStatsJson() }
+  }
+
+  if (subcommand === 'hide' || subcommand === 'dismiss') {
+    context.setAppState(prev => ({
+      ...prev,
+      companionReaction: undefined,
+    }))
+    return {
+      type: 'text',
+      value: `${companion.name} settles down quietly.`,
+    }
+  }
+
+  const lastReaction = context.getAppState().companionReaction
+  const muted = !!getGlobalConfig().companionMuted
+  const card = renderCompanionCard(companion, lastReaction)
+  const suffix = muted
+    ? '\n\nStatus: muted'
+    : '\n\nStatus: active'
+
+  return {
+    type: 'text',
+    value: `${card}${suffix}`,
+  }
+}
+

--- a/src/commands/buddy/index.ts
+++ b/src/commands/buddy/index.ts
@@ -1,0 +1,13 @@
+import type { Command } from '../../commands.js'
+
+const buddy = {
+  type: 'local',
+  name: 'buddy',
+  description: 'Show your companion, pet it, or toggle reactions',
+  argumentHint: '[show|pet|stats|mute|unmute]',
+  supportsNonInteractive: true,
+  load: () => import('./buddy.js'),
+} satisfies Command
+
+export default buddy
+

--- a/src/commands/ultraplan.tsx
+++ b/src/commands/ultraplan.tsx
@@ -3,15 +3,22 @@ import { DIAMOND_OPEN } from '../constants/figures.js'
 import type { AppState } from '../state/AppStateStore.js'
 import type { LocalJSXCommandCall } from '../types/command.js'
 import {
+  parseUltraplanArgs,
+  type UltraplanProfile,
+} from '../utils/ultraplan/profile.js'
+import {
   startLocalUltraplan,
   stopLocalUltraplan,
 } from '../utils/ultraplan/localSession.js'
 
-function buildLaunchMessage(disconnectedBridge?: boolean): string {
+function buildLaunchMessage(
+  profile: UltraplanProfile,
+  disconnectedBridge?: boolean,
+): string {
   const prefix = disconnectedBridge
     ? 'Remote control was disconnected first. '
     : ''
-  return `${DIAMOND_OPEN} ultraplan\n${prefix}Starting a local planner in a new terminal...`
+  return `${DIAMOND_OPEN} ultraplan\n${prefix}Starting a ${profile} local planner in a new terminal...`
 }
 
 function buildAlreadyActiveMessage(localRef: string | undefined): string {
@@ -22,6 +29,7 @@ function buildAlreadyActiveMessage(localRef: string | undefined): string {
 
 export async function launchUltraplan(opts: {
   blurb: string
+  profile?: UltraplanProfile
   seedPlan?: string
   getAppState: () => AppState
   setAppState: (f: (prev: AppState) => AppState) => void
@@ -31,6 +39,7 @@ export async function launchUltraplan(opts: {
 }): Promise<string> {
   const {
     blurb,
+    profile = 'deep',
     seedPlan,
     getAppState,
     setAppState,
@@ -45,11 +54,13 @@ export async function launchUltraplan(opts: {
 
   if (!blurb && !seedPlan) {
     return [
-      'Usage: /ultraplan <prompt>, or include "ultraplan" in your prompt.',
+      'Usage: /ultraplan [--fast|--deep|--max] <prompt>, or include "ultraplan" in your prompt.',
       '',
       'This launches a new local terminal and runs a planning-only session.',
       'The planner inspects the repo, writes a deep plan locally, and then lets',
       'you insert that plan back into the current conversation.',
+      '',
+      'Profiles: --fast (quick), --deep (default), --max (most thorough).',
     ].join('\n')
   }
 
@@ -60,6 +71,7 @@ export async function launchUltraplan(opts: {
 
   void startLocalUltraplan({
     topic: blurb || 'Refine the existing plan',
+    profile,
     seedPlan,
     getAppState,
     setAppState,
@@ -73,7 +85,7 @@ export async function launchUltraplan(opts: {
     console.error(error)
   })
 
-  return buildLaunchMessage(disconnectedBridge)
+  return buildLaunchMessage(profile, disconnectedBridge)
 }
 
 export async function stopUltraplan(
@@ -85,11 +97,13 @@ export async function stopUltraplan(
 }
 
 const call: LocalJSXCommandCall = async (onDone, context, args) => {
-  const blurb = args.trim()
+  const parsed = parseUltraplanArgs(args)
+  const blurb = parsed.blurb
 
   if (!blurb) {
     const msg = await launchUltraplan({
       blurb,
+      profile: parsed.profile,
       getAppState: context.getAppState,
       setAppState: context.setAppState,
       signal: context.abortController.signal,
@@ -107,7 +121,7 @@ const call: LocalJSXCommandCall = async (onDone, context, args) => {
 
   context.setAppState(prev => ({
     ...prev,
-    ultraplanLaunchPending: { blurb },
+    ultraplanLaunchPending: { blurb, profile: parsed.profile },
   }))
   onDone(undefined, { display: 'skip' })
   return null
@@ -117,8 +131,8 @@ export default {
   type: 'local-jsx',
   name: 'ultraplan',
   description:
-    '~5-15 min · Launch a local planning session in a new terminal and bring the resulting plan back here',
-  argumentHint: '<prompt>',
+    '~5-15 min local planning session in a new terminal that returns a plan here',
+  argumentHint: '[--fast|--deep|--max] <prompt>',
   isEnabled: () => true,
   load: () => Promise.resolve({ call }),
 } satisfies Command

--- a/src/commands/ultraplan.tsx
+++ b/src/commands/ultraplan.tsx
@@ -1,471 +1,124 @@
-import { readFileSync } from 'fs';
-import { REMOTE_CONTROL_DISCONNECTED_MSG } from '../bridge/types.js';
-import type { Command } from '../commands.js';
-import { DIAMOND_OPEN } from '../constants/figures.js';
-import { getRemoteSessionUrl } from '../constants/product.js';
-import { getFeatureValue_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js';
-import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../services/analytics/index.js';
-import type { AppState } from '../state/AppStateStore.js';
-import { checkRemoteAgentEligibility, formatPreconditionError, RemoteAgentTask, type RemoteAgentTaskState, registerRemoteAgentTask } from '../tasks/RemoteAgentTask/RemoteAgentTask.js';
-import type { LocalJSXCommandCall } from '../types/command.js';
-import { logForDebugging } from '../utils/debug.js';
-import { errorMessage } from '../utils/errors.js';
-import { logError } from '../utils/log.js';
-import { enqueuePendingNotification } from '../utils/messageQueueManager.js';
-import { ALL_MODEL_CONFIGS } from '../utils/model/configs.js';
-import { updateTaskState } from '../utils/task/framework.js';
-import { archiveRemoteSession, teleportToRemote } from '../utils/teleport.js';
-import { pollForApprovedExitPlanMode, UltraplanPollError } from '../utils/ultraplan/ccrSession.js';
+import type { Command } from '../commands.js'
+import { DIAMOND_OPEN } from '../constants/figures.js'
+import type { AppState } from '../state/AppStateStore.js'
+import type { LocalJSXCommandCall } from '../types/command.js'
+import {
+  startLocalUltraplan,
+  stopLocalUltraplan,
+} from '../utils/ultraplan/localSession.js'
 
-// TODO(prod-hardening): OAuth token may go stale over the 30min poll;
-// consider refresh.
-
-// Multi-agent exploration is slow; 30min timeout.
-const ULTRAPLAN_TIMEOUT_MS = 30 * 60 * 1000;
-export const CCR_TERMS_URL = 'https://code.claude.com/docs/en/claude-code-on-the-web';
-
-// CCR runs against the first-party API — use the canonical ID, not the
-// provider-specific string getModelStrings() would return (which may be a
-// Bedrock ARN or Vertex ID on the local CLI). Read at call time, not module
-// load: the GrowthBook cache is empty at import and `/config` Gates can flip
-// it between invocations.
-function getUltraplanModel(): string {
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_ultraplan_model', ALL_MODEL_CONFIGS.opus46.firstParty);
-}
-
-// prompt.txt is wrapped in <system-reminder> so the CCR browser hides
-// scaffolding (CLI_BLOCK_TAGS dropped by stripSystemNotifications)
-// while the model still sees full text.
-// Phrasing deliberately avoids the feature name because
-// the remote CCR CLI runs keyword detection on raw input before
-// any tag stripping, and a bare "ultraplan" in the prompt would self-trigger as
-// /ultraplan, which is filtered out of headless mode as "Unknown skill"
-//
-// Bundler inlines .txt as a string; the test runner wraps it as {default}.
-/* eslint-disable @typescript-eslint/no-require-imports */
-const _rawPrompt = require('../utils/ultraplan/prompt.txt');
-/* eslint-enable @typescript-eslint/no-require-imports */
-const DEFAULT_INSTRUCTIONS: string = (typeof _rawPrompt === 'string' ? _rawPrompt : _rawPrompt.default).trimEnd();
-
-// Dev-only prompt override resolved eagerly at module load.
-// Gated to ant builds (USER_TYPE is a build-time define,
-// so the override path is DCE'd from external builds).
-// Shell-set env only, so top-level process.env read is fine
-// — settings.env never injects this.
-/* eslint-disable custom-rules/no-process-env-top-level, custom-rules/no-sync-fs -- ant-only dev override; eager top-level read is the point (crash at startup, not silently inside the slash-command try/catch) */
-const ULTRAPLAN_INSTRUCTIONS: string = "external" === 'ant' && process.env.ULTRAPLAN_PROMPT_FILE ? readFileSync(process.env.ULTRAPLAN_PROMPT_FILE, 'utf8').trimEnd() : DEFAULT_INSTRUCTIONS;
-/* eslint-enable custom-rules/no-process-env-top-level, custom-rules/no-sync-fs */
-
-/**
- * Assemble the initial CCR user message. seedPlan and blurb stay outside the
- * system-reminder so the browser renders them; scaffolding is hidden.
- */
-export function buildUltraplanPrompt(blurb: string, seedPlan?: string): string {
-  const parts: string[] = [];
-  if (seedPlan) {
-    parts.push('Here is a draft plan to refine:', '', seedPlan, '');
-  }
-  parts.push(ULTRAPLAN_INSTRUCTIONS);
-  if (blurb) {
-    parts.push('', blurb);
-  }
-  return parts.join('\n');
-}
-function startDetachedPoll(taskId: string, sessionId: string, url: string, getAppState: () => AppState, setAppState: (f: (prev: AppState) => AppState) => void): void {
-  const started = Date.now();
-  let failed = false;
-  void (async () => {
-    try {
-      const {
-        plan,
-        rejectCount,
-        executionTarget
-      } = await pollForApprovedExitPlanMode(sessionId, ULTRAPLAN_TIMEOUT_MS, phase => {
-        if (phase === 'needs_input') logEvent('tengu_ultraplan_awaiting_input', {});
-        updateTaskState<RemoteAgentTaskState>(taskId, setAppState, t => {
-          if (t.status !== 'running') return t;
-          const next = phase === 'running' ? undefined : phase;
-          return t.ultraplanPhase === next ? t : {
-            ...t,
-            ultraplanPhase: next
-          };
-        });
-      }, () => getAppState().tasks?.[taskId]?.status !== 'running');
-      logEvent('tengu_ultraplan_approved', {
-        duration_ms: Date.now() - started,
-        plan_length: plan.length,
-        reject_count: rejectCount,
-        execution_target: executionTarget as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-      });
-      if (executionTarget === 'remote') {
-        // User chose "execute in CCR" in the browser PlanModal — the remote
-        // session is now coding. Skip archive (ARCHIVE has no running-check,
-        // would kill mid-execution) and skip the choice dialog (already chose).
-        // Guard on task status so a poll that resolves after stopUltraplan
-        // doesn't notify for a killed session.
-        const task = getAppState().tasks?.[taskId];
-        if (task?.status !== 'running') return;
-        updateTaskState<RemoteAgentTaskState>(taskId, setAppState, t => t.status !== 'running' ? t : {
-          ...t,
-          status: 'completed',
-          endTime: Date.now()
-        });
-        setAppState(prev => prev.ultraplanSessionUrl === url ? {
-          ...prev,
-          ultraplanSessionUrl: undefined
-        } : prev);
-        enqueuePendingNotification({
-          value: [`Ultraplan approved — executing in Claude Code on the web. Follow along at: ${url}`, '', 'Results will land as a pull request when the remote session finishes. There is nothing to do here.'].join('\n'),
-          mode: 'task-notification'
-        });
-      } else {
-        // Teleport: set pendingChoice so REPL mounts UltraplanChoiceDialog.
-        // The dialog owns archive + URL clear on choice. Guard on task status
-        // so a poll that resolves after stopUltraplan doesn't resurrect the
-        // dialog for a killed session.
-        setAppState(prev => {
-          const task = prev.tasks?.[taskId];
-          if (!task || task.status !== 'running') return prev;
-          return {
-            ...prev,
-            ultraplanPendingChoice: {
-              plan,
-              sessionId,
-              taskId
-            }
-          };
-        });
-      }
-    } catch (e) {
-      // If the task was stopped (stopUltraplan sets status=killed), the poll
-      // erroring is expected — skip the failure notification and cleanup
-      // (kill() already archived; stopUltraplan cleared the URL).
-      const task = getAppState().tasks?.[taskId];
-      if (task?.status !== 'running') return;
-      failed = true;
-      logEvent('tengu_ultraplan_failed', {
-        duration_ms: Date.now() - started,
-        reason: (e instanceof UltraplanPollError ? e.reason : 'network_or_unknown') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        reject_count: e instanceof UltraplanPollError ? e.rejectCount : undefined
-      });
-      enqueuePendingNotification({
-        value: `Ultraplan failed: ${errorMessage(e)}\n\nSession: ${url}`,
-        mode: 'task-notification'
-      });
-      // Error path owns cleanup; teleport path defers to the dialog; remote
-      // path handled its own cleanup above.
-      void archiveRemoteSession(sessionId).catch(e => logForDebugging(`ultraplan archive failed: ${String(e)}`));
-      setAppState(prev =>
-      // Compare against this poll's URL so a newer relaunched session's
-      // URL isn't cleared by a stale poll erroring out.
-      prev.ultraplanSessionUrl === url ? {
-        ...prev,
-        ultraplanSessionUrl: undefined
-      } : prev);
-    } finally {
-      // Remote path already set status=completed above; teleport path
-      // leaves status=running so the pill shows the ultraplanPhase state
-      // until UltraplanChoiceDialog completes the task after the user's
-      // choice. Setting completed here would filter the task out of
-      // isBackgroundTask before the pill can render the phase state.
-      // Failure path has no dialog, so it owns the status transition here.
-      if (failed) {
-        updateTaskState<RemoteAgentTaskState>(taskId, setAppState, t => t.status !== 'running' ? t : {
-          ...t,
-          status: 'failed',
-          endTime: Date.now()
-        });
-      }
-    }
-  })();
-}
-
-// Renders immediately so the terminal doesn't appear hung during the
-// multi-second teleportToRemote round-trip.
 function buildLaunchMessage(disconnectedBridge?: boolean): string {
-  const prefix = disconnectedBridge ? `${REMOTE_CONTROL_DISCONNECTED_MSG} ` : '';
-  return `${DIAMOND_OPEN} ultraplan\n${prefix}Starting Claude Code on the web…`;
-}
-function buildSessionReadyMessage(url: string): string {
-  return `${DIAMOND_OPEN} ultraplan · Monitor progress in Claude Code on the web ${url}\nYou can continue working — when the ${DIAMOND_OPEN} fills, press ↓ to view results`;
-}
-function buildAlreadyActiveMessage(url: string | undefined): string {
-  return url ? `ultraplan: already polling. Open ${url} to check status, or wait for the plan to land here.` : 'ultraplan: already launching. Please wait for the session to start.';
+  const prefix = disconnectedBridge
+    ? 'Remote control was disconnected first. '
+    : ''
+  return `${DIAMOND_OPEN} ultraplan\n${prefix}Starting a local planner in a new terminal...`
 }
 
-/**
- * Stop a running ultraplan: archive the remote session (halts it but keeps the
- * URL viewable), kill the local task entry (clears the pill), and clear
- * ultraplanSessionUrl (re-arms the keyword trigger). startDetachedPoll's
- * shouldStop callback sees the killed status on its next tick and throws;
- * the catch block early-returns when status !== 'running'.
- */
-export async function stopUltraplan(taskId: string, sessionId: string, setAppState: (f: (prev: AppState) => AppState) => void): Promise<void> {
-  // RemoteAgentTask.kill archives the session (with .catch) — no separate
-  // archive call needed here.
-  await RemoteAgentTask.kill(taskId, setAppState);
-  setAppState(prev => prev.ultraplanSessionUrl || prev.ultraplanPendingChoice || prev.ultraplanLaunching ? {
-    ...prev,
-    ultraplanSessionUrl: undefined,
-    ultraplanPendingChoice: undefined,
-    ultraplanLaunching: undefined
-  } : prev);
-  const url = getRemoteSessionUrl(sessionId, process.env.SESSION_INGRESS_URL);
-  enqueuePendingNotification({
-    value: `Ultraplan stopped.\n\nSession: ${url}`,
-    mode: 'task-notification'
-  });
-  enqueuePendingNotification({
-    value: 'The user stopped the ultraplan session above. Do not respond to the stop notification — wait for their next message.',
-    mode: 'task-notification',
-    isMeta: true
-  });
+function buildAlreadyActiveMessage(localRef: string | undefined): string {
+  return localRef
+    ? `ultraplan: already running. Current local run: ${localRef}`
+    : 'ultraplan: already launching. Please wait for the local planner to start.'
 }
 
-/**
- * Shared entry for the slash command, keyword trigger, and the plan-approval
- * dialog's "Ultraplan" button. When seedPlan is present (dialog path), it is
- * prepended as a draft to refine; blurb may be empty in that case.
- *
- * Resolves immediately with the user-facing message. Eligibility check,
- * session creation, and task registration run detached and failures surface via
- * enqueuePendingNotification.
- */
 export async function launchUltraplan(opts: {
-  blurb: string;
-  seedPlan?: string;
-  getAppState: () => AppState;
-  setAppState: (f: (prev: AppState) => AppState) => void;
-  signal: AbortSignal;
-  /** True if the caller disconnected Remote Control before launching. */
-  disconnectedBridge?: boolean;
-  /**
-   * Called once teleportToRemote resolves with a session URL. Callers that
-   * have setMessages (REPL) append this as a second transcript message so the
-   * URL is visible without opening the ↓ detail view. Callers without
-   * transcript access (ExitPlanModePermissionRequest) omit this — the pill
-   * still shows live status.
-   */
-  onSessionReady?: (msg: string) => void;
+  blurb: string
+  seedPlan?: string
+  getAppState: () => AppState
+  setAppState: (f: (prev: AppState) => AppState) => void
+  signal: AbortSignal
+  disconnectedBridge?: boolean
+  onSessionReady?: (msg: string) => void
 }): Promise<string> {
   const {
     blurb,
     seedPlan,
     getAppState,
     setAppState,
-    signal,
+    onSessionReady,
     disconnectedBridge,
-    onSessionReady
-  } = opts;
-  const {
-    ultraplanSessionUrl: active,
-    ultraplanLaunching
-  } = getAppState();
+  } = opts
+
+  const { ultraplanSessionUrl: active, ultraplanLaunching } = getAppState()
   if (active || ultraplanLaunching) {
-    logEvent('tengu_ultraplan_create_failed', {
-      reason: (active ? 'already_polling' : 'already_launching') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-    });
-    return buildAlreadyActiveMessage(active);
-  }
-  if (!blurb && !seedPlan) {
-    // No event — bare /ultraplan is a usage query, not an attempt.
-    return [
-    // Rendered via <Markdown>; raw <message> is tokenized as HTML
-    // and dropped. Backslash-escape the brackets.
-    'Usage: /ultraplan \\<prompt\\>, or include "ultraplan" anywhere', 'in your prompt', '', 'Advanced multi-agent plan mode with our most powerful model', '(Opus). Runs in Claude Code on the web. When the plan is ready,', 'you can execute it in the web session or send it back here.', 'Terminal stays free while the remote plans.', 'Requires /login.', '', `Terms: ${CCR_TERMS_URL}`].join('\n');
+    return buildAlreadyActiveMessage(active)
   }
 
-  // Set synchronously before the detached flow to prevent duplicate launches
-  // during the teleportToRemote window.
-  setAppState(prev => prev.ultraplanLaunching ? prev : {
+  if (!blurb && !seedPlan) {
+    return [
+      'Usage: /ultraplan <prompt>, or include "ultraplan" in your prompt.',
+      '',
+      'This launches a new local terminal and runs a planning-only session.',
+      'The planner inspects the repo, writes a deep plan locally, and then lets',
+      'you insert that plan back into the current conversation.',
+    ].join('\n')
+  }
+
+  setAppState(prev => ({
     ...prev,
-    ultraplanLaunching: true
-  });
-  void launchDetached({
-    blurb,
+    ultraplanLaunching: true,
+  }))
+
+  void startLocalUltraplan({
+    topic: blurb || 'Refine the existing plan',
     seedPlan,
     getAppState,
     setAppState,
-    signal,
-    onSessionReady
-  });
-  return buildLaunchMessage(disconnectedBridge);
-}
-async function launchDetached(opts: {
-  blurb: string;
-  seedPlan?: string;
-  getAppState: () => AppState;
-  setAppState: (f: (prev: AppState) => AppState) => void;
-  signal: AbortSignal;
-  onSessionReady?: (msg: string) => void;
-}): Promise<void> {
-  const {
-    blurb,
-    seedPlan,
-    getAppState,
-    setAppState,
-    signal,
-    onSessionReady
-  } = opts;
-  // Hoisted so the catch block can archive the remote session if an error
-  // occurs after teleportToRemote succeeds (avoids 30min orphan).
-  let sessionId: string | undefined;
-  try {
-    const model = getUltraplanModel();
-    const eligibility = await checkRemoteAgentEligibility();
-    if (!eligibility.eligible) {
-      logEvent('tengu_ultraplan_create_failed', {
-        reason: 'precondition' as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        precondition_errors: eligibility.errors.map(e => e.type).join(',') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-      });
-      const reasons = eligibility.errors.map(formatPreconditionError).join('\n');
-      enqueuePendingNotification({
-        value: `ultraplan: cannot launch remote session —\n${reasons}`,
-        mode: 'task-notification'
-      });
-      return;
-    }
-    const prompt = buildUltraplanPrompt(blurb, seedPlan);
-    let bundleFailMsg: string | undefined;
-    const session = await teleportToRemote({
-      initialMessage: prompt,
-      description: blurb || 'Refine local plan',
-      model,
-      permissionMode: 'plan',
-      ultraplan: true,
-      signal,
-      useDefaultEnvironment: true,
-      onBundleFail: msg => {
-        bundleFailMsg = msg;
-      }
-    });
-    if (!session) {
-      logEvent('tengu_ultraplan_create_failed', {
-        reason: (bundleFailMsg ? 'bundle_fail' : 'teleport_null') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-      });
-      enqueuePendingNotification({
-        value: `ultraplan: session creation failed${bundleFailMsg ? ` — ${bundleFailMsg}` : ''}. See --debug for details.`,
-        mode: 'task-notification'
-      });
-      return;
-    }
-    sessionId = session.id;
-    const url = getRemoteSessionUrl(session.id, process.env.SESSION_INGRESS_URL);
+    onSessionReady,
+  }).catch(error => {
     setAppState(prev => ({
       ...prev,
-      ultraplanSessionUrl: url,
-      ultraplanLaunching: undefined
-    }));
-    onSessionReady?.(buildSessionReadyMessage(url));
-    logEvent('tengu_ultraplan_launched', {
-      has_seed_plan: Boolean(seedPlan),
-      model: model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-    });
-    // TODO(#23985): replace registerRemoteAgentTask + startDetachedPoll with
-    // ExitPlanModeScanner inside startRemoteSessionPolling.
-    const {
-      taskId
-    } = registerRemoteAgentTask({
-      remoteTaskType: 'ultraplan',
-      session: {
-        id: session.id,
-        title: blurb || 'Ultraplan'
-      },
-      command: blurb,
-      context: {
-        abortController: new AbortController(),
-        getAppState,
-        setAppState
-      },
-      isUltraplan: true
-    });
-    startDetachedPoll(taskId, session.id, url, getAppState, setAppState);
-  } catch (e) {
-    logError(e);
-    logEvent('tengu_ultraplan_create_failed', {
-      reason: 'unexpected_error' as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-    });
-    enqueuePendingNotification({
-      value: `ultraplan: unexpected error — ${errorMessage(e)}`,
-      mode: 'task-notification'
-    });
-    if (sessionId) {
-      // Error after teleport succeeded — archive so the remote doesn't sit
-      // running for 30min with nobody polling it.
-      void archiveRemoteSession(sessionId).catch(err => logForDebugging('ultraplan: failed to archive orphaned session', err));
-      // ultraplanSessionUrl may have been set before the throw; clear it so
-      // the "already polling" guard doesn't block future launches.
-      setAppState(prev => prev.ultraplanSessionUrl ? {
-        ...prev,
-        ultraplanSessionUrl: undefined
-      } : prev);
-    }
-  } finally {
-    // No-op on success: the url-setting setAppState already cleared this.
-    setAppState(prev => prev.ultraplanLaunching ? {
-      ...prev,
-      ultraplanLaunching: undefined
-    } : prev);
-  }
-}
-const call: LocalJSXCommandCall = async (onDone, context, args) => {
-  const blurb = args.trim();
+      ultraplanLaunching: undefined,
+      ultraplanSessionUrl: undefined,
+    }))
+    console.error(error)
+  })
 
-  // Bare /ultraplan (no args, no seed plan) just shows usage — no dialog.
+  return buildLaunchMessage(disconnectedBridge)
+}
+
+export async function stopUltraplan(
+  taskId: string,
+  sessionId: string,
+  setAppState: (f: (prev: AppState) => AppState) => void,
+): Promise<void> {
+  await stopLocalUltraplan(taskId, sessionId, setAppState)
+}
+
+const call: LocalJSXCommandCall = async (onDone, context, args) => {
+  const blurb = args.trim()
+
   if (!blurb) {
     const msg = await launchUltraplan({
       blurb,
       getAppState: context.getAppState,
       setAppState: context.setAppState,
-      signal: context.abortController.signal
-    });
-    onDone(msg, {
-      display: 'system'
-    });
-    return null;
+      signal: context.abortController.signal,
+    })
+    onDone(msg, { display: 'system' })
+    return null
   }
 
-  // Guard matches launchUltraplan's own check — showing the dialog when a
-  // session is already active or launching would waste the user's click and set
-  // hasSeenUltraplanTerms before the launch fails.
-  const {
-    ultraplanSessionUrl: active,
-    ultraplanLaunching
-  } = context.getAppState();
+  const { ultraplanSessionUrl: active, ultraplanLaunching } =
+    context.getAppState()
   if (active || ultraplanLaunching) {
-    logEvent('tengu_ultraplan_create_failed', {
-      reason: (active ? 'already_polling' : 'already_launching') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-    });
-    onDone(buildAlreadyActiveMessage(active), {
-      display: 'system'
-    });
-    return null;
+    onDone(buildAlreadyActiveMessage(active), { display: 'system' })
+    return null
   }
 
-  // Mount the pre-launch dialog via focusedInputDialog (bottom region, like
-  // permission dialogs) rather than returning JSX (transcript area, anchors
-  // at top of scrollback). REPL.tsx handles launch/clear/cancel on choice.
   context.setAppState(prev => ({
     ...prev,
-    ultraplanLaunchPending: {
-      blurb
-    }
-  }));
-  // 'skip' suppresses the (no content) echo — the dialog's choice handler
-  // adds the real /ultraplan echo + launch confirmation.
-  onDone(undefined, {
-    display: 'skip'
-  });
-  return null;
-};
+    ultraplanLaunchPending: { blurb },
+  }))
+  onDone(undefined, { display: 'skip' })
+  return null
+}
+
 export default {
   type: 'local-jsx',
   name: 'ultraplan',
-  description: `~10–30 min · Claude Code on the web drafts an advanced plan you can edit and approve. See ${CCR_TERMS_URL}`,
+  description:
+    '~5-15 min · Launch a local planning session in a new terminal and bring the resulting plan back here',
   argumentHint: '<prompt>',
   isEnabled: () => true,
-  load: () => Promise.resolve({
-    call
-  })
-} satisfies Command;
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJyZWFkRmlsZVN5bmMiLCJSRU1PVEVfQ09OVFJPTF9ESVNDT05ORUNURURfTVNHIiwiQ29tbWFuZCIsIkRJQU1PTkRfT1BFTiIsImdldFJlbW90ZVNlc3Npb25VcmwiLCJnZXRGZWF0dXJlVmFsdWVfQ0FDSEVEX01BWV9CRV9TVEFMRSIsIkFuYWx5dGljc01ldGFkYXRhX0lfVkVSSUZJRURfVEhJU19JU19OT1RfQ09ERV9PUl9GSUxFUEFUSFMiLCJsb2dFdmVudCIsIkFwcFN0YXRlIiwiY2hlY2tSZW1vdGVBZ2VudEVsaWdpYmlsaXR5IiwiZm9ybWF0UHJlY29uZGl0aW9uRXJyb3IiLCJSZW1vdGVBZ2VudFRhc2siLCJSZW1vdGVBZ2VudFRhc2tTdGF0ZSIsInJlZ2lzdGVyUmVtb3RlQWdlbnRUYXNrIiwiTG9jYWxKU1hDb21tYW5kQ2FsbCIsImxvZ0ZvckRlYnVnZ2luZyIsImVycm9yTWVzc2FnZSIsImxvZ0Vycm9yIiwiZW5xdWV1ZVBlbmRpbmdOb3RpZmljYXRpb24iLCJBTExfTU9ERUxfQ09ORklHUyIsInVwZGF0ZVRhc2tTdGF0ZSIsImFyY2hpdmVSZW1vdGVTZXNzaW9uIiwidGVsZXBvcnRUb1JlbW90ZSIsInBvbGxGb3JBcHByb3ZlZEV4aXRQbGFuTW9kZSIsIlVsdHJhcGxhblBvbGxFcnJvciIsIlVMVFJBUExBTl9USU1FT1VUX01TIiwiQ0NSX1RFUk1TX1VSTCIsImdldFVsdHJhcGxhbk1vZGVsIiwib3B1czQ2IiwiZmlyc3RQYXJ0eSIsIl9yYXdQcm9tcHQiLCJyZXF1aXJlIiwiREVGQVVMVF9JTlNUUlVDVElPTlMiLCJkZWZhdWx0IiwidHJpbUVuZCIsIlVMVFJBUExBTl9JTlNUUlVDVElPTlMiLCJwcm9jZXNzIiwiZW52IiwiVUxUUkFQTEFOX1BST01QVF9GSUxFIiwiYnVpbGRVbHRyYXBsYW5Qcm9tcHQiLCJibHVyYiIsInNlZWRQbGFuIiwicGFydHMiLCJwdXNoIiwiam9pbiIsInN0YXJ0RGV0YWNoZWRQb2xsIiwidGFza0lkIiwic2Vzc2lvbklkIiwidXJsIiwiZ2V0QXBwU3RhdGUiLCJzZXRBcHBTdGF0ZSIsImYiLCJwcmV2Iiwic3RhcnRlZCIsIkRhdGUiLCJub3ciLCJmYWlsZWQiLCJwbGFuIiwicmVqZWN0Q291bnQiLCJleGVjdXRpb25UYXJnZXQiLCJwaGFzZSIsInQiLCJzdGF0dXMiLCJuZXh0IiwidW5kZWZpbmVkIiwidWx0cmFwbGFuUGhhc2UiLCJ0YXNrcyIsImR1cmF0aW9uX21zIiwicGxhbl9sZW5ndGgiLCJsZW5ndGgiLCJyZWplY3RfY291bnQiLCJleGVjdXRpb25fdGFyZ2V0IiwidGFzayIsImVuZFRpbWUiLCJ1bHRyYXBsYW5TZXNzaW9uVXJsIiwidmFsdWUiLCJtb2RlIiwidWx0cmFwbGFuUGVuZGluZ0Nob2ljZSIsImUiLCJyZWFzb24iLCJjYXRjaCIsIlN0cmluZyIsImJ1aWxkTGF1bmNoTWVzc2FnZSIsImRpc2Nvbm5lY3RlZEJyaWRnZSIsInByZWZpeCIsImJ1aWxkU2Vzc2lvblJlYWR5TWVzc2FnZSIsImJ1aWxkQWxyZWFkeUFjdGl2ZU1lc3NhZ2UiLCJzdG9wVWx0cmFwbGFuIiwiUHJvbWlzZSIsImtpbGwiLCJ1bHRyYXBsYW5MYXVuY2hpbmciLCJTRVNTSU9OX0lOR1JFU1NfVVJMIiwiaXNNZXRhIiwibGF1bmNoVWx0cmFwbGFuIiwib3B0cyIsInNpZ25hbCIsIkFib3J0U2lnbmFsIiwib25TZXNzaW9uUmVhZHkiLCJtc2ciLCJhY3RpdmUiLCJsYXVuY2hEZXRhY2hlZCIsIm1vZGVsIiwiZWxpZ2liaWxpdHkiLCJlbGlnaWJsZSIsInByZWNvbmRpdGlvbl9lcnJvcnMiLCJlcnJvcnMiLCJtYXAiLCJ0eXBlIiwicmVhc29ucyIsInByb21wdCIsImJ1bmRsZUZhaWxNc2ciLCJzZXNzaW9uIiwiaW5pdGlhbE1lc3NhZ2UiLCJkZXNjcmlwdGlvbiIsInBlcm1pc3Npb25Nb2RlIiwidWx0cmFwbGFuIiwidXNlRGVmYXVsdEVudmlyb25tZW50Iiwib25CdW5kbGVGYWlsIiwiaWQiLCJoYXNfc2VlZF9wbGFuIiwiQm9vbGVhbiIsInJlbW90ZVRhc2tUeXBlIiwidGl0bGUiLCJjb21tYW5kIiwiY29udGV4dCIsImFib3J0Q29udHJvbGxlciIsIkFib3J0Q29udHJvbGxlciIsImlzVWx0cmFwbGFuIiwiZXJyIiwiY2FsbCIsIm9uRG9uZSIsImFyZ3MiLCJ0cmltIiwiZGlzcGxheSIsInVsdHJhcGxhbkxhdW5jaFBlbmRpbmciLCJuYW1lIiwiYXJndW1lbnRIaW50IiwiaXNFbmFibGVkIiwibG9hZCIsInJlc29sdmUiXSwic291cmNlcyI6WyJ1bHRyYXBsYW4udHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IHJlYWRGaWxlU3luYyB9IGZyb20gJ2ZzJ1xuaW1wb3J0IHsgUkVNT1RFX0NPTlRST0xfRElTQ09OTkVDVEVEX01TRyB9IGZyb20gJy4uL2JyaWRnZS90eXBlcy5qcydcbmltcG9ydCB0eXBlIHsgQ29tbWFuZCB9IGZyb20gJy4uL2NvbW1hbmRzLmpzJ1xuaW1wb3J0IHsgRElBTU9ORF9PUEVOIH0gZnJvbSAnLi4vY29uc3RhbnRzL2ZpZ3VyZXMuanMnXG5pbXBvcnQgeyBnZXRSZW1vdGVTZXNzaW9uVXJsIH0gZnJvbSAnLi4vY29uc3RhbnRzL3Byb2R1Y3QuanMnXG5pbXBvcnQgeyBnZXRGZWF0dXJlVmFsdWVfQ0FDSEVEX01BWV9CRV9TVEFMRSB9IGZyb20gJy4uL3NlcnZpY2VzL2FuYWx5dGljcy9ncm93dGhib29rLmpzJ1xuaW1wb3J0IHtcbiAgdHlwZSBBbmFseXRpY3NNZXRhZGF0YV9JX1ZFUklGSUVEX1RISVNfSVNfTk9UX0NPREVfT1JfRklMRVBBVEhTLFxuICBsb2dFdmVudCxcbn0gZnJvbSAnLi4vc2VydmljZXMvYW5hbHl0aWNzL2luZGV4LmpzJ1xuaW1wb3J0IHR5cGUgeyBBcHBTdGF0ZSB9IGZyb20gJy4uL3N0YXRlL0FwcFN0YXRlU3RvcmUuanMnXG5pbXBvcnQge1xuICBjaGVja1JlbW90ZUFnZW50RWxpZ2liaWxpdHksXG4gIGZvcm1hdFByZWNvbmRpdGlvbkVycm9yLFxuICBSZW1vdGVBZ2VudFRhc2ssXG4gIHR5cGUgUmVtb3RlQWdlbnRUYXNrU3RhdGUsXG4gIHJlZ2lzdGVyUmVtb3RlQWdlbnRUYXNrLFxufSBmcm9tICcuLi90YXNrcy9SZW1vdGVBZ2VudFRhc2svUmVtb3RlQWdlbnRUYXNrLmpzJ1xuaW1wb3J0IHR5cGUgeyBMb2NhbEpTWENvbW1hbmRDYWxsIH0gZnJvbSAnLi4vdHlwZXMvY29tbWFuZC5qcydcbmltcG9ydCB7IGxvZ0ZvckRlYnVnZ2luZyB9IGZyb20gJy4uL3V0aWxzL2RlYnVnLmpzJ1xuaW1wb3J0IHsgZXJyb3JNZXNzYWdlIH0gZnJvbSAnLi4vdXRpbHMvZXJyb3JzLmpzJ1xuaW1wb3J0IHsgbG9nRXJyb3IgfSBmcm9tICcuLi91dGlscy9sb2cuanMnXG5pbXBvcnQgeyBlbnF1ZXVlUGVuZGluZ05vdGlmaWNhdGlvbiB9IGZyb20gJy4uL3V0aWxzL21lc3NhZ2VRdWV1ZU1hbmFnZXIuanMnXG5pbXBvcnQgeyBBTExfTU9ERUxfQ09ORklHUyB9IGZyb20gJy4uL3V0aWxzL21vZGVsL2NvbmZpZ3MuanMnXG5pbXBvcnQgeyB1cGRhdGVUYXNrU3RhdGUgfSBmcm9tICcuLi91dGlscy90YXNrL2ZyYW1ld29yay5qcydcbmltcG9ydCB7IGFyY2hpdmVSZW1vdGVTZXNzaW9uLCB0ZWxlcG9ydFRvUmVtb3RlIH0gZnJvbSAnLi4vdXRpbHMvdGVsZXBvcnQuanMnXG5pbXBvcnQge1xuICBwb2xsRm9yQXBwcm92ZWRFeGl0UGxhbk1vZGUsXG4gIFVsdHJhcGxhblBvbGxFcnJvcixcbn0gZnJvbSAnLi4vdXRpbHMvdWx0cmFwbGFuL2NjclNlc3Npb24uanMnXG5cbi8vIFRPRE8ocHJvZC1oYXJkZW5pbmcpOiBPQXV0aCB0b2tlbiBtYXkgZ28gc3RhbGUgb3ZlciB0aGUgMzBtaW4gcG9sbDtcbi8vIGNvbnNpZGVyIHJlZnJlc2guXG5cbi8vIE11bHRpLWFnZW50IGV4cGxvcmF0aW9uIGlzIHNsb3c7IDMwbWluIHRpbWVvdXQuXG5jb25zdCBVTFRSQVBMQU5fVElNRU9VVF9NUyA9IDMwICogNjAgKiAxMDAwXG5cbmV4cG9ydCBjb25zdCBDQ1JfVEVSTVNfVVJMID1cbiAgJ2h0dHBzOi8vY29kZS5jbGF1ZGUuY29tL2RvY3MvZW4vY2xhdWRlLWNvZGUtb24tdGhlLXdlYidcblxuLy8gQ0NSIHJ1bnMgYWdhaW5zdCB0aGUgZmlyc3QtcGFydHkgQVBJIOKAlCB1c2UgdGhlIGNhbm9uaWNhbCBJRCwgbm90IHRoZVxuLy8gcHJvdmlkZXItc3BlY2lmaWMgc3RyaW5nIGdldE1vZGVsU3RyaW5ncygpIHdvdWxkIHJldHVybiAod2hpY2ggbWF5IGJlIGFcbi8vIEJlZHJvY2sgQVJOIG9yIFZlcnRleCBJRCBvbiB0aGUgbG9jYWwgQ0xJKS4gUmVhZCBhdCBjYWxsIHRpbWUsIG5vdCBtb2R1bGVcbi8vIGxvYWQ6IHRoZSBHcm93dGhCb29rIGNhY2hlIGlzIGVtcHR5IGF0IGltcG9ydCBhbmQgYC9jb25maWdgIEdhdGVzIGNhbiBmbGlwXG4vLyBpdCBiZXR3ZWVuIGludm9jYXRpb25zLlxuZnVuY3Rpb24gZ2V0VWx0cmFwbGFuTW9kZWwoKTogc3RyaW5nIHtcbiAgcmV0dXJuIGdldEZlYXR1cmVWYWx1ZV9DQUNIRURfTUFZX0JFX1NUQUxFKFxuICAgICd0ZW5ndV91bHRyYXBsYW5fbW9kZWwnLFxuICAgIEFMTF9NT0RFTF9DT05GSUdTLm9wdXM0Ni5maXJzdFBhcnR5LFxuICApXG59XG5cbi8vIHByb21wdC50eHQgaXMgd3JhcHBlZCBpbiA8c3lzdGVtLXJlbWluZGVyPiBzbyB0aGUgQ0NSIGJyb3dzZXIgaGlkZXNcbi8vIHNjYWZmb2xkaW5nIChDTElfQkxPQ0tfVEFHUyBkcm9wcGVkIGJ5IHN0cmlwU3lzdGVtTm90aWZpY2F0aW9ucylcbi8vIHdoaWxlIHRoZSBtb2RlbCBzdGlsbCBzZWVzIGZ1bGwgdGV4dC5cbi8vIFBocmFzaW5nIGRlbGliZXJhdGVseSBhdm9pZHMgdGhlIGZlYXR1cmUgbmFtZSBiZWNhdXNlXG4vLyB0aGUgcmVtb3RlIENDUiBDTEkgcnVucyBrZXl3b3JkIGRldGVjdGlvbiBvbiByYXcgaW5wdXQgYmVmb3JlXG4vLyBhbnkgdGFnIHN0cmlwcGluZywgYW5kIGEgYmFyZSBcInVsdHJhcGxhblwiIGluIHRoZSBwcm9tcHQgd291bGQgc2VsZi10cmlnZ2VyIGFzXG4vLyAvdWx0cmFwbGFuLCB3aGljaCBpcyBmaWx0ZXJlZCBvdXQgb2YgaGVhZGxlc3MgbW9kZSBhcyBcIlVua25vd24gc2tpbGxcIlxuLy9cbi8vIEJ1bmRsZXIgaW5saW5lcyAudHh0IGFzIGEgc3RyaW5nOyB0aGUgdGVzdCBydW5uZXIgd3JhcHMgaXQgYXMge2RlZmF1bHR9LlxuLyogZXNsaW50LWRpc2FibGUgQHR5cGVzY3JpcHQtZXNsaW50L25vLXJlcXVpcmUtaW1wb3J0cyAqL1xuY29uc3QgX3Jhd1Byb21wdCA9IHJlcXVpcmUoJy4uL3V0aWxzL3VsdHJhcGxhbi9wcm9tcHQudHh0Jylcbi8qIGVzbGludC1lbmFibGUgQHR5cGVzY3JpcHQtZXNsaW50L25vLXJlcXVpcmUtaW1wb3J0cyAqL1xuY29uc3QgREVGQVVMVF9JTlNUUlVDVElPTlM6IHN0cmluZyA9IChcbiAgdHlwZW9mIF9yYXdQcm9tcHQgPT09ICdzdHJpbmcnID8gX3Jhd1Byb21wdCA6IF9yYXdQcm9tcHQuZGVmYXVsdFxuKS50cmltRW5kKClcblxuLy8gRGV2LW9ubHkgcHJvbXB0IG92ZXJyaWRlIHJlc29sdmVkIGVhZ2VybHkgYXQgbW9kdWxlIGxvYWQuXG4vLyBHYXRlZCB0byBhbnQgYnVpbGRzIChVU0VSX1RZUEUgaXMgYSBidWlsZC10aW1lIGRlZmluZSxcbi8vIHNvIHRoZSBvdmVycmlkZSBwYXRoIGlzIERDRSdkIGZyb20gZXh0ZXJuYWwgYnVpbGRzKS5cbi8vIFNoZWxsLXNldCBlbnYgb25seSwgc28gdG9wLWxldmVsIHByb2Nlc3MuZW52IHJlYWQgaXMgZmluZVxuLy8g4oCUIHNldHRpbmdzLmVudiBuZXZlciBpbmplY3RzIHRoaXMuXG4vKiBlc2xpbnQtZGlzYWJsZSBjdXN0b20tcnVsZXMvbm8tcHJvY2Vzcy1lbnYtdG9wLWxldmVsLCBjdXN0b20tcnVsZXMvbm8tc3luYy1mcyAtLSBhbnQtb25seSBkZXYgb3ZlcnJpZGU7IGVhZ2VyIHRvcC1sZXZlbCByZWFkIGlzIHRoZSBwb2ludCAoY3Jhc2ggYXQgc3RhcnR1cCwgbm90IHNpbGVudGx5IGluc2lkZSB0aGUgc2xhc2gtY29tbWFuZCB0cnkvY2F0Y2gpICovXG5jb25zdCBVTFRSQVBMQU5fSU5TVFJVQ1RJT05TOiBzdHJpbmcgPVxuICBcImV4dGVybmFsXCIgPT09ICdhbnQnICYmIHByb2Nlc3MuZW52LlVMVFJBUExBTl9QUk9NUFRfRklMRVxuICAgID8gcmVhZEZpbGVTeW5jKHByb2Nlc3MuZW52LlVMVFJBUExBTl9QUk9NUFRfRklMRSwgJ3V0ZjgnKS50cmltRW5kKClcbiAgICA6IERFRkFVTFRfSU5TVFJVQ1RJT05TXG4vKiBlc2xpbnQtZW5hYmxlIGN1c3RvbS1ydWxlcy9uby1wcm9jZXNzLWVudi10b3AtbGV2ZWwsIGN1c3RvbS1ydWxlcy9uby1zeW5jLWZzICovXG5cbi8qKlxuICogQXNzZW1ibGUgdGhlIGluaXRpYWwgQ0NSIHVzZXIgbWVzc2FnZS4gc2VlZFBsYW4gYW5kIGJsdXJiIHN0YXkgb3V0c2lkZSB0aGVcbiAqIHN5c3RlbS1yZW1pbmRlciBzbyB0aGUgYnJvd3NlciByZW5kZXJzIHRoZW07IHNjYWZmb2xkaW5nIGlzIGhpZGRlbi5cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGJ1aWxkVWx0cmFwbGFuUHJvbXB0KGJsdXJiOiBzdHJpbmcsIHNlZWRQbGFuPzogc3RyaW5nKTogc3RyaW5nIHtcbiAgY29uc3QgcGFydHM6IHN0cmluZ1tdID0gW11cbiAgaWYgKHNlZWRQbGFuKSB7XG4gICAgcGFydHMucHVzaCgnSGVyZSBpcyBhIGRyYWZ0IHBsYW4gdG8gcmVmaW5lOicsICcnLCBzZWVkUGxhbiwgJycpXG4gIH1cbiAgcGFydHMucHVzaChVTFRSQVBMQU5fSU5TVFJVQ1RJT05TKVxuICBpZiAoYmx1cmIpIHtcbiAgICBwYXJ0cy5wdXNoKCcnLCBibHVyYilcbiAgfVxuICByZXR1cm4gcGFydHMuam9pbignXFxuJylcbn1cblxuZnVuY3Rpb24gc3RhcnREZXRhY2hlZFBvbGwoXG4gIHRhc2tJZDogc3RyaW5nLFxuICBzZXNzaW9uSWQ6IHN0cmluZyxcbiAgdXJsOiBzdHJpbmcsXG4gIGdldEFwcFN0YXRlOiAoKSA9PiBBcHBTdGF0ZSxcbiAgc2V0QXBwU3RhdGU6IChmOiAocHJldjogQXBwU3RhdGUpID0+IEFwcFN0YXRlKSA9PiB2b2lkLFxuKTogdm9pZCB7XG4gIGNvbnN0IHN0YXJ0ZWQgPSBEYXRlLm5vdygpXG4gIGxldCBmYWlsZWQgPSBmYWxzZVxuICB2b2lkIChhc3luYyAoKSA9PiB7XG4gICAgdHJ5IHtcbiAgICAgIGNvbnN0IHsgcGxhbiwgcmVqZWN0Q291bnQsIGV4ZWN1dGlvblRhcmdldCB9ID1cbiAgICAgICAgYXdhaXQgcG9sbEZvckFwcHJvdmVkRXhpdFBsYW5Nb2RlKFxuICAgICAgICAgIHNlc3Npb25JZCxcbiAgICAgICAgICBVTFRSQVBMQU5fVElNRU9VVF9NUyxcbiAgICAgICAgICBwaGFzZSA9PiB7XG4gICAgICAgICAgICBpZiAocGhhc2UgPT09ICduZWVkc19pbnB1dCcpXG4gICAgICAgICAgICAgIGxvZ0V2ZW50KCd0ZW5ndV91bHRyYXBsYW5fYXdhaXRpbmdfaW5wdXQnLCB7fSlcbiAgICAgICAgICAgIHVwZGF0ZVRhc2tTdGF0ZTxSZW1vdGVBZ2VudFRhc2tTdGF0ZT4odGFza0lkLCBzZXRBcHBTdGF0ZSwgdCA9PiB7XG4gICAgICAgICAgICAgIGlmICh0LnN0YXR1cyAhPT0gJ3J1bm5pbmcnKSByZXR1cm4gdFxuICAgICAgICAgICAgICBjb25zdCBuZXh0ID0gcGhhc2UgPT09ICdydW5uaW5nJyA/IHVuZGVmaW5lZCA6IHBoYXNlXG4gICAgICAgICAgICAgIHJldHVybiB0LnVsdHJhcGxhblBoYXNlID09PSBuZXh0XG4gICAgICAgICAgICAgICAgPyB0XG4gICAgICAgICAgICAgICAgOiB7IC4uLnQsIHVsdHJhcGxhblBoYXNlOiBuZXh0IH1cbiAgICAgICAgICAgIH0pXG4gICAgICAgICAgfSxcbiAgICAgICAgICAoKSA9PiBnZXRBcHBTdGF0ZSgpLnRhc2tzPy5bdGFza0lkXT8uc3RhdHVzICE9PSAncnVubmluZycsXG4gICAgICAgIClcbiAgICAgIGxvZ0V2ZW50KCd0ZW5ndV91bHRyYXBsYW5fYXBwcm92ZWQnLCB7XG4gICAgICAgIGR1cmF0aW9uX21zOiBEYXRlLm5vdygpIC0gc3RhcnRlZCxcbiAgICAgICAgcGxhbl9sZW5ndGg6IHBsYW4ubGVuZ3RoLFxuICAgICAgICByZWplY3RfY291bnQ6IHJlamVjdENvdW50LFxuICAgICAgICBleGVjdXRpb25fdGFyZ2V0OlxuICAgICAgICAgIGV4ZWN1dGlvblRhcmdldCBhcyBBbmFseXRpY3NNZXRhZGF0YV9JX1ZFUklGSUVEX1RISVNfSVNfTk9UX0NPREVfT1JfRklMRVBBVEhTLFxuICAgICAgfSlcbiAgICAgIGlmIChleGVjdXRpb25UYXJnZXQgPT09ICdyZW1vdGUnKSB7XG4gICAgICAgIC8vIFVzZXIgY2hvc2UgXCJleGVjdXRlIGluIENDUlwiIGluIHRoZSBicm93c2VyIFBsYW5Nb2RhbCDigJQgdGhlIHJlbW90ZVxuICAgICAgICAvLyBzZXNzaW9uIGlzIG5vdyBjb2RpbmcuIFNraXAgYXJjaGl2ZSAoQVJDSElWRSBoYXMgbm8gcnVubmluZy1jaGVjayxcbiAgICAgICAgLy8gd291bGQga2lsbCBtaWQtZXhlY3V0aW9uKSBhbmQgc2tpcCB0aGUgY2hvaWNlIGRpYWxvZyAoYWxyZWFkeSBjaG9zZSkuXG4gICAgICAgIC8vIEd1YXJkIG9uIHRhc2sgc3RhdHVzIHNvIGEgcG9sbCB0aGF0IHJlc29sdmVzIGFmdGVyIHN0b3BVbHRyYXBsYW5cbiAgICAgICAgLy8gZG9lc24ndCBub3RpZnkgZm9yIGEga2lsbGVkIHNlc3Npb24uXG4gICAgICAgIGNvbnN0IHRhc2sgPSBnZXRBcHBTdGF0ZSgpLnRhc2tzPy5bdGFza0lkXVxuICAgICAgICBpZiAodGFzaz8uc3RhdHVzICE9PSAncnVubmluZycpIHJldHVyblxuICAgICAgICB1cGRhdGVUYXNrU3RhdGU8UmVtb3RlQWdlbnRUYXNrU3RhdGU+KHRhc2tJZCwgc2V0QXBwU3RhdGUsIHQgPT5cbiAgICAgICAgICB0LnN0YXR1cyAhPT0gJ3J1bm5pbmcnXG4gICAgICAgICAgICA/IHRcbiAgICAgICAgICAgIDogeyAuLi50LCBzdGF0dXM6ICdjb21wbGV0ZWQnLCBlbmRUaW1lOiBEYXRlLm5vdygpIH0sXG4gICAgICAgIClcbiAgICAgICAgc2V0QXBwU3RhdGUocHJldiA9PlxuICAgICAgICAgIHByZXYudWx0cmFwbGFuU2Vzc2lvblVybCA9PT0gdXJsXG4gICAgICAgICAgICA/IHsgLi4ucHJldiwgdWx0cmFwbGFuU2Vzc2lvblVybDogdW5kZWZpbmVkIH1cbiAgICAgICAgICAgIDogcHJldixcbiAgICAgICAgKVxuICAgICAgICBlbnF1ZXVlUGVuZGluZ05vdGlmaWNhdGlvbih7XG4gICAgICAgICAgdmFsdWU6IFtcbiAgICAgICAgICAgIGBVbHRyYXBsYW4gYXBwcm92ZWQg4oCUIGV4ZWN1dGluZyBpbiBDbGF1ZGUgQ29kZSBvbiB0aGUgd2ViLiBGb2xsb3cgYWxvbmcgYXQ6ICR7dXJsfWAsXG4gICAgICAgICAgICAnJyxcbiAgICAgICAgICAgICdSZXN1bHRzIHdpbGwgbGFuZCBhcyBhIHB1bGwgcmVxdWVzdCB3aGVuIHRoZSByZW1vdGUgc2Vzc2lvbiBmaW5pc2hlcy4gVGhlcmUgaXMgbm90aGluZyB0byBkbyBoZXJlLicsXG4gICAgICAgICAgXS5qb2luKCdcXG4nKSxcbiAgICAgICAgICBtb2RlOiAndGFzay1ub3RpZmljYXRpb24nLFxuICAgICAgICB9KVxuICAgICAgfSBlbHNlIHtcbiAgICAgICAgLy8gVGVsZXBvcnQ6IHNldCBwZW5kaW5nQ2hvaWNlIHNvIFJFUEwgbW91bnRzIFVsdHJhcGxhbkNob2ljZURpYWxvZy5cbiAgICAgICAgLy8gVGhlIGRpYWxvZyBvd25zIGFyY2hpdmUgKyBVUkwgY2xlYXIgb24gY2hvaWNlLiBHdWFyZCBvbiB0YXNrIHN0YXR1c1xuICAgICAgICAvLyBzbyBhIHBvbGwgdGhhdCByZXNvbHZlcyBhZnRlciBzdG9wVWx0cmFwbGFuIGRvZXNuJ3QgcmVzdXJyZWN0IHRoZVxuICAgICAgICAvLyBkaWFsb2cgZm9yIGEga2lsbGVkIHNlc3Npb24uXG4gICAgICAgIHNldEFwcFN0YXRlKHByZXYgPT4ge1xuICAgICAgICAgIGNvbnN0IHRhc2sgPSBwcmV2LnRhc2tzPy5bdGFza0lkXVxuICAgICAgICAgIGlmICghdGFzayB8fCB0YXNrLnN0YXR1cyAhPT0gJ3J1bm5pbmcnKSByZXR1cm4gcHJldlxuICAgICAgICAgIHJldHVybiB7XG4gICAgICAgICAgICAuLi5wcmV2LFxuICAgICAgICAgICAgdWx0cmFwbGFuUGVuZGluZ0Nob2ljZTogeyBwbGFuLCBzZXNzaW9uSWQsIHRhc2tJZCB9LFxuICAgICAgICAgIH1cbiAgICAgICAgfSlcbiAgICAgIH1cbiAgICB9IGNhdGNoIChlKSB7XG4gICAgICAvLyBJZiB0aGUgdGFzayB3YXMgc3RvcHBlZCAoc3RvcFVsdHJhcGxhbiBzZXRzIHN0YXR1cz1raWxsZWQpLCB0aGUgcG9sbFxuICAgICAgLy8gZXJyb3JpbmcgaXMgZXhwZWN0ZWQg4oCUIHNraXAgdGhlIGZhaWx1cmUgbm90aWZpY2F0aW9uIGFuZCBjbGVhbnVwXG4gICAgICAvLyAoa2lsbCgpIGFscmVhZHkgYXJjaGl2ZWQ7IHN0b3BVbHRyYXBsYW4gY2xlYXJlZCB0aGUgVVJMKS5cbiAgICAgIGNvbnN0IHRhc2sgPSBnZXRBcHBTdGF0ZSgpLnRhc2tzPy5bdGFza0lkXVxuICAgICAgaWYgKHRhc2s/LnN0YXR1cyAhPT0gJ3J1bm5pbmcnKSByZXR1cm5cbiAgICAgIGZhaWxlZCA9IHRydWVcbiAgICAgIGxvZ0V2ZW50KCd0ZW5ndV91bHRyYXBsYW5fZmFpbGVkJywge1xuICAgICAgICBkdXJhdGlvbl9tczogRGF0ZS5ub3coKSAtIHN0YXJ0ZWQsXG4gICAgICAgIHJlYXNvbjogKGUgaW5zdGFuY2VvZiBVbHRyYXBsYW5Qb2xsRXJyb3JcbiAgICAgICAgICA/IGUucmVhc29uXG4gICAgICAgICAgOiAnbmV0d29ya19vcl91bmtub3duJykgYXMgQW5hbHl0aWNzTWV0YWRhdGFfSV9WRVJJRklFRF9USElTX0lTX05PVF9DT0RFX09SX0ZJTEVQQVRIUyxcbiAgICAgICAgcmVqZWN0X2NvdW50OlxuICAgICAgICAgIGUgaW5zdGFuY2VvZiBVbHRyYXBsYW5Qb2xsRXJyb3IgPyBlLnJlamVjdENvdW50IDogdW5kZWZpbmVkLFxuICAgICAgfSlcbiAgICAgIGVucXVldWVQZW5kaW5nTm90aWZpY2F0aW9uKHtcbiAgICAgICAgdmFsdWU6IGBVbHRyYXBsYW4gZmFpbGVkOiAke2Vycm9yTWVzc2FnZShlKX1cXG5cXG5TZXNzaW9uOiAke3VybH1gLFxuICAgICAgICBtb2RlOiAndGFzay1ub3RpZmljYXRpb24nLFxuICAgICAgfSlcbiAgICAgIC8vIEVycm9yIHBhdGggb3ducyBjbGVhbnVwOyB0ZWxlcG9ydCBwYXRoIGRlZmVycyB0byB0aGUgZGlhbG9nOyByZW1vdGVcbiAgICAgIC8vIHBhdGggaGFuZGxlZCBpdHMgb3duIGNsZWFudXAgYWJvdmUuXG4gICAgICB2b2lkIGFyY2hpdmVSZW1vdGVTZXNzaW9uKHNlc3Npb25JZCkuY2F0Y2goZSA9PlxuICAgICAgICBsb2dGb3JEZWJ1Z2dpbmcoYHVsdHJhcGxhbiBhcmNoaXZlIGZhaWxlZDogJHtTdHJpbmcoZSl9YCksXG4gICAgICApXG4gICAgICBzZXRBcHBTdGF0ZShwcmV2ID0+XG4gICAgICAgIC8vIENvbXBhcmUgYWdhaW5zdCB0aGlzIHBvbGwncyBVUkwgc28gYSBuZXdlciByZWxhdW5jaGVkIHNlc3Npb24nc1xuICAgICAgICAvLyBVUkwgaXNuJ3QgY2xlYXJlZCBieSBhIHN0YWxlIHBvbGwgZXJyb3Jpbmcgb3V0LlxuICAgICAgICBwcmV2LnVsdHJhcGxhblNlc3Npb25VcmwgPT09IHVybFxuICAgICAgICAgID8geyAuLi5wcmV2LCB1bHRyYXBsYW5TZXNzaW9uVXJsOiB1bmRlZmluZWQgfVxuICAgICAgICAgIDogcHJldixcbiAgICAgIClcbiAgICB9IGZpbmFsbHkge1xuICAgICAgLy8gUmVtb3RlIHBhdGggYWxyZWFkeSBzZXQgc3RhdHVzPWNvbXBsZXRlZCBhYm92ZTsgdGVsZXBvcnQgcGF0aFxuICAgICAgLy8gbGVhdmVzIHN0YXR1cz1ydW5uaW5nIHNvIHRoZSBwaWxsIHNob3dzIHRoZSB1bHRyYXBsYW5QaGFzZSBzdGF0ZVxuICAgICAgLy8gdW50aWwgVWx0cmFwbGFuQ2hvaWNlRGlhbG9nIGNvbXBsZXRlcyB0aGUgdGFzayBhZnRlciB0aGUgdXNlcidzXG4gICAgICAvLyBjaG9pY2UuIFNldHRpbmcgY29tcGxldGVkIGhlcmUgd291bGQgZmlsdGVyIHRoZSB0YXNrIG91dCBvZlxuICAgICAgLy8gaXNCYWNrZ3JvdW5kVGFzayBiZWZvcmUgdGhlIHBpbGwgY2FuIHJlbmRlciB0aGUgcGhhc2Ugc3RhdGUuXG4gICAgICAvLyBGYWlsdXJlIHBhdGggaGFzIG5vIGRpYWxvZywgc28gaXQgb3ducyB0aGUgc3RhdHVzIHRyYW5zaXRpb24gaGVyZS5cbiAgICAgIGlmIChmYWlsZWQpIHtcbiAgICAgICAgdXBkYXRlVGFza1N0YXRlPFJlbW90ZUFnZW50VGFza1N0YXRlPih0YXNrSWQsIHNldEFwcFN0YXRlLCB0ID0+XG4gICAgICAgICAgdC5zdGF0dXMgIT09ICdydW5uaW5nJ1xuICAgICAgICAgICAgPyB0XG4gICAgICAgICAgICA6IHsgLi4udCwgc3RhdHVzOiAnZmFpbGVkJywgZW5kVGltZTogRGF0ZS5ub3coKSB9LFxuICAgICAgICApXG4gICAgICB9XG4gICAgfVxuICB9KSgpXG59XG5cbi8vIFJlbmRlcnMgaW1tZWRpYXRlbHkgc28gdGhlIHRlcm1pbmFsIGRvZXNuJ3QgYXBwZWFyIGh1bmcgZHVyaW5nIHRoZVxuLy8gbXVsdGktc2Vjb25kIHRlbGVwb3J0VG9SZW1vdGUgcm91bmQtdHJpcC5cbmZ1bmN0aW9uIGJ1aWxkTGF1bmNoTWVzc2FnZShkaXNjb25uZWN0ZWRCcmlkZ2U/OiBib29sZWFuKTogc3RyaW5nIHtcbiAgY29uc3QgcHJlZml4ID0gZGlzY29ubmVjdGVkQnJpZGdlID8gYCR7UkVNT1RFX0NPTlRST0xfRElTQ09OTkVDVEVEX01TR30gYCA6ICcnXG4gIHJldHVybiBgJHtESUFNT05EX09QRU59IHVsdHJhcGxhblxcbiR7cHJlZml4fVN0YXJ0aW5nIENsYXVkZSBDb2RlIG9uIHRoZSB3ZWLigKZgXG59XG5cbmZ1bmN0aW9uIGJ1aWxkU2Vzc2lvblJlYWR5TWVzc2FnZSh1cmw6IHN0cmluZyk6IHN0cmluZyB7XG4gIHJldHVybiBgJHtESUFNT05EX09QRU59IHVsdHJhcGxhbiDCtyBNb25pdG9yIHByb2dyZXNzIGluIENsYXVkZSBDb2RlIG9uIHRoZSB3ZWIgJHt1cmx9XFxuWW91IGNhbiBjb250aW51ZSB3b3JraW5nIOKAlCB3aGVuIHRoZSAke0RJQU1PTkRfT1BFTn0gZmlsbHMsIHByZXNzIOKGkyB0byB2aWV3IHJlc3VsdHNgXG59XG5cbmZ1bmN0aW9uIGJ1aWxkQWxyZWFkeUFjdGl2ZU1lc3NhZ2UodXJsOiBzdHJpbmcgfCB1bmRlZmluZWQpOiBzdHJpbmcge1xuICByZXR1cm4gdXJsXG4gICAgPyBgdWx0cmFwbGFuOiBhbHJlYWR5IHBvbGxpbmcuIE9wZW4gJHt1cmx9IHRvIGNoZWNrIHN0YXR1cywgb3Igd2FpdCBmb3IgdGhlIHBsYW4gdG8gbGFuZCBoZXJlLmBcbiAgICA6ICd1bHRyYXBsYW46IGFscmVhZHkgbGF1bmNoaW5nLiBQbGVhc2Ugd2FpdCBmb3IgdGhlIHNlc3Npb24gdG8gc3RhcnQuJ1xufVxuXG4vKipcbiAqIFN0b3AgYSBydW5uaW5nIHVsdHJhcGxhbjogYXJjaGl2ZSB0aGUgcmVtb3RlIHNlc3Npb24gKGhhbHRzIGl0IGJ1dCBrZWVwcyB0aGVcbiAqIFVSTCB2aWV3YWJsZSksIGtpbGwgdGhlIGxvY2FsIHRhc2sgZW50cnkgKGNsZWFycyB0aGUgcGlsbCksIGFuZCBjbGVhclxuICogdWx0cmFwbGFuU2Vzc2lvblVybCAocmUtYXJtcyB0aGUga2V5d29yZCB0cmlnZ2VyKS4gc3RhcnREZXRhY2hlZFBvbGwnc1xuICogc2hvdWxkU3RvcCBjYWxsYmFjayBzZWVzIHRoZSBraWxsZWQgc3RhdHVzIG9uIGl0cyBuZXh0IHRpY2sgYW5kIHRocm93cztcbiAqIHRoZSBjYXRjaCBibG9jayBlYXJseS1yZXR1cm5zIHdoZW4gc3RhdHVzICE9PSAncnVubmluZycuXG4gKi9cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBzdG9wVWx0cmFwbGFuKFxuICB0YXNrSWQ6IHN0cmluZyxcbiAgc2Vzc2lvbklkOiBzdHJpbmcsXG4gIHNldEFwcFN0YXRlOiAoZjogKHByZXY6IEFwcFN0YXRlKSA9PiBBcHBTdGF0ZSkgPT4gdm9pZCxcbik6IFByb21pc2U8dm9pZD4ge1xuICAvLyBSZW1vdGVBZ2VudFRhc2sua2lsbCBhcmNoaXZlcyB0aGUgc2Vzc2lvbiAod2l0aCAuY2F0Y2gpIOKAlCBubyBzZXBhcmF0ZVxuICAvLyBhcmNoaXZlIGNhbGwgbmVlZGVkIGhlcmUuXG4gIGF3YWl0IFJlbW90ZUFnZW50VGFzay5raWxsKHRhc2tJZCwgc2V0QXBwU3RhdGUpXG4gIHNldEFwcFN0YXRlKHByZXYgPT5cbiAgICBwcmV2LnVsdHJhcGxhblNlc3Npb25VcmwgfHxcbiAgICBwcmV2LnVsdHJhcGxhblBlbmRpbmdDaG9pY2UgfHxcbiAgICBwcmV2LnVsdHJhcGxhbkxhdW5jaGluZ1xuICAgICAgPyB7XG4gICAgICAgICAgLi4ucHJldixcbiAgICAgICAgICB1bHRyYXBsYW5TZXNzaW9uVXJsOiB1bmRlZmluZWQsXG4gICAgICAgICAgdWx0cmFwbGFuUGVuZGluZ0Nob2ljZTogdW5kZWZpbmVkLFxuICAgICAgICAgIHVsdHJhcGxhbkxhdW5jaGluZzogdW5kZWZpbmVkLFxuICAgICAgICB9XG4gICAgICA6IHByZXYsXG4gIClcbiAgY29uc3QgdXJsID0gZ2V0UmVtb3RlU2Vzc2lvblVybChzZXNzaW9uSWQsIHByb2Nlc3MuZW52LlNFU1NJT05fSU5HUkVTU19VUkwpXG4gIGVucXVldWVQZW5kaW5nTm90aWZpY2F0aW9uKHtcbiAgICB2YWx1ZTogYFVsdHJhcGxhbiBzdG9wcGVkLlxcblxcblNlc3Npb246ICR7dXJsfWAsXG4gICAgbW9kZTogJ3Rhc2stbm90aWZpY2F0aW9uJyxcbiAgfSlcbiAgZW5xdWV1ZVBlbmRpbmdOb3RpZmljYXRpb24oe1xuICAgIHZhbHVlOlxuICAgICAgJ1RoZSB1c2VyIHN0b3BwZWQgdGhlIHVsdHJhcGxhbiBzZXNzaW9uIGFib3ZlLiBEbyBub3QgcmVzcG9uZCB0byB0aGUgc3RvcCBub3RpZmljYXRpb24g4oCUIHdhaXQgZm9yIHRoZWlyIG5leHQgbWVzc2FnZS4nLFxuICAgIG1vZGU6ICd0YXNrLW5vdGlmaWNhdGlvbicsXG4gICAgaXNNZXRhOiB0cnVlLFxuICB9KVxufVxuXG4vKipcbiAqIFNoYXJlZCBlbnRyeSBmb3IgdGhlIHNsYXNoIGNvbW1hbmQsIGtleXdvcmQgdHJpZ2dlciwgYW5kIHRoZSBwbGFuLWFwcHJvdmFsXG4gKiBkaWFsb2cncyBcIlVsdHJhcGxhblwiIGJ1dHRvbi4gV2hlbiBzZWVkUGxhbiBpcyBwcmVzZW50IChkaWFsb2cgcGF0aCksIGl0IGlzXG4gKiBwcmVwZW5kZWQgYXMgYSBkcmFmdCB0byByZWZpbmU7IGJsdXJiIG1heSBiZSBlbXB0eSBpbiB0aGF0IGNhc2UuXG4gKlxuICogUmVzb2x2ZXMgaW1tZWRpYXRlbHkgd2l0aCB0aGUgdXNlci1mYWNpbmcgbWVzc2FnZS4gRWxpZ2liaWxpdHkgY2hlY2ssXG4gKiBzZXNzaW9uIGNyZWF0aW9uLCBhbmQgdGFzayByZWdpc3RyYXRpb24gcnVuIGRldGFjaGVkIGFuZCBmYWlsdXJlcyBzdXJmYWNlIHZpYVxuICogZW5xdWV1ZVBlbmRpbmdOb3RpZmljYXRpb24uXG4gKi9cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBsYXVuY2hVbHRyYXBsYW4ob3B0czoge1xuICBibHVyYjogc3RyaW5nXG4gIHNlZWRQbGFuPzogc3RyaW5nXG4gIGdldEFwcFN0YXRlOiAoKSA9PiBBcHBTdGF0ZVxuICBzZXRBcHBTdGF0ZTogKGY6IChwcmV2OiBBcHBTdGF0ZSkgPT4gQXBwU3RhdGUpID0+IHZvaWRcbiAgc2lnbmFsOiBBYm9ydFNpZ25hbFxuICAvKiogVHJ1ZSBpZiB0aGUgY2FsbGVyIGRpc2Nvbm5lY3RlZCBSZW1vdGUgQ29udHJvbCBiZWZvcmUgbGF1bmNoaW5nLiAqL1xuICBkaXNjb25uZWN0ZWRCcmlkZ2U/OiBib29sZWFuXG4gIC8qKlxuICAgKiBDYWxsZWQgb25jZSB0ZWxlcG9ydFRvUmVtb3RlIHJlc29sdmVzIHdpdGggYSBzZXNzaW9uIFVSTC4gQ2FsbGVycyB0aGF0XG4gICAqIGhhdmUgc2V0TWVzc2FnZXMgKFJFUEwpIGFwcGVuZCB0aGlzIGFzIGEgc2Vjb25kIHRyYW5zY3JpcHQgbWVzc2FnZSBzbyB0aGVcbiAgICogVVJMIGlzIHZpc2libGUgd2l0aG91dCBvcGVuaW5nIHRoZSDihpMgZGV0YWlsIHZpZXcuIENhbGxlcnMgd2l0aG91dFxuICAgKiB0cmFuc2NyaXB0IGFjY2VzcyAoRXhpdFBsYW5Nb2RlUGVybWlzc2lvblJlcXVlc3QpIG9taXQgdGhpcyDigJQgdGhlIHBpbGxcbiAgICogc3RpbGwgc2hvd3MgbGl2ZSBzdGF0dXMuXG4gICAqL1xuICBvblNlc3Npb25SZWFkeT86IChtc2c6IHN0cmluZykgPT4gdm9pZFxufSk6IFByb21pc2U8c3RyaW5nPiB7XG4gIGNvbnN0IHtcbiAgICBibHVyYixcbiAgICBzZWVkUGxhbixcbiAgICBnZXRBcHBTdGF0ZSxcbiAgICBzZXRBcHBTdGF0ZSxcbiAgICBzaWduYWwsXG4gICAgZGlzY29ubmVjdGVkQnJpZGdlLFxuICAgIG9uU2Vzc2lvblJlYWR5LFxuICB9ID0gb3B0c1xuXG4gIGNvbnN0IHsgdWx0cmFwbGFuU2Vzc2lvblVybDogYWN0aXZlLCB1bHRyYXBsYW5MYXVuY2hpbmcgfSA9IGdldEFwcFN0YXRlKClcbiAgaWYgKGFjdGl2ZSB8fCB1bHRyYXBsYW5MYXVuY2hpbmcpIHtcbiAgICBsb2dFdmVudCgndGVuZ3VfdWx0cmFwbGFuX2NyZWF0ZV9mYWlsZWQnLCB7XG4gICAgICByZWFzb246IChhY3RpdmVcbiAgICAgICAgPyAnYWxyZWFkeV9wb2xsaW5nJ1xuICAgICAgICA6ICdhbHJlYWR5X2xhdW5jaGluZycpIGFzIEFuYWx5dGljc01ldGFkYXRhX0lfVkVSSUZJRURfVEhJU19JU19OT1RfQ09ERV9PUl9GSUxFUEFUSFMsXG4gICAgfSlcbiAgICByZXR1cm4gYnVpbGRBbHJlYWR5QWN0aXZlTWVzc2FnZShhY3RpdmUpXG4gIH1cblxuICBpZiAoIWJsdXJiICYmICFzZWVkUGxhbikge1xuICAgIC8vIE5vIGV2ZW50IOKAlCBiYXJlIC91bHRyYXBsYW4gaXMgYSB1c2FnZSBxdWVyeSwgbm90IGFuIGF0dGVtcHQuXG4gICAgcmV0dXJuIFtcbiAgICAgIC8vIFJlbmRlcmVkIHZpYSA8TWFya2Rvd24+OyByYXcgPG1lc3NhZ2U+IGlzIHRva2VuaXplZCBhcyBIVE1MXG4gICAgICAvLyBhbmQgZHJvcHBlZC4gQmFja3NsYXNoLWVzY2FwZSB0aGUgYnJhY2tldHMuXG4gICAgICAnVXNhZ2U6IC91bHRyYXBsYW4gXFxcXDxwcm9tcHRcXFxcPiwgb3IgaW5jbHVkZSBcInVsdHJhcGxhblwiIGFueXdoZXJlJyxcbiAgICAgICdpbiB5b3VyIHByb21wdCcsXG4gICAgICAnJyxcbiAgICAgICdBZHZhbmNlZCBtdWx0aS1hZ2VudCBwbGFuIG1vZGUgd2l0aCBvdXIgbW9zdCBwb3dlcmZ1bCBtb2RlbCcsXG4gICAgICAnKE9wdXMpLiBSdW5zIGluIENsYXVkZSBDb2RlIG9uIHRoZSB3ZWIuIFdoZW4gdGhlIHBsYW4gaXMgcmVhZHksJyxcbiAgICAgICd5b3UgY2FuIGV4ZWN1dGUgaXQgaW4gdGhlIHdlYiBzZXNzaW9uIG9yIHNlbmQgaXQgYmFjayBoZXJlLicsXG4gICAgICAnVGVybWluYWwgc3RheXMgZnJlZSB3aGlsZSB0aGUgcmVtb3RlIHBsYW5zLicsXG4gICAgICAnUmVxdWlyZXMgL2xvZ2luLicsXG4gICAgICAnJyxcbiAgICAgIGBUZXJtczogJHtDQ1JfVEVSTVNfVVJMfWAsXG4gICAgXS5qb2luKCdcXG4nKVxuICB9XG5cbiAgLy8gU2V0IHN5bmNocm9ub3VzbHkgYmVmb3JlIHRoZSBkZXRhY2hlZCBmbG93IHRvIHByZXZlbnQgZHVwbGljYXRlIGxhdW5jaGVzXG4gIC8vIGR1cmluZyB0aGUgdGVsZXBvcnRUb1JlbW90ZSB3aW5kb3cuXG4gIHNldEFwcFN0YXRlKHByZXYgPT5cbiAgICBwcmV2LnVsdHJhcGxhbkxhdW5jaGluZyA/IHByZXYgOiB7IC4uLnByZXYsIHVsdHJhcGxhbkxhdW5jaGluZzogdHJ1ZSB9LFxuICApXG4gIHZvaWQgbGF1bmNoRGV0YWNoZWQoe1xuICAgIGJsdXJiLFxuICAgIHNlZWRQbGFuLFxuICAgIGdldEFwcFN0YXRlLFxuICAgIHNldEFwcFN0YXRlLFxuICAgIHNpZ25hbCxcbiAgICBvblNlc3Npb25SZWFkeSxcbiAgfSlcbiAgcmV0dXJuIGJ1aWxkTGF1bmNoTWVzc2FnZShkaXNjb25uZWN0ZWRCcmlkZ2UpXG59XG5cbmFzeW5jIGZ1bmN0aW9uIGxhdW5jaERldGFjaGVkKG9wdHM6IHtcbiAgYmx1cmI6IHN0cmluZ1xuICBzZWVkUGxhbj86IHN0cmluZ1xuICBnZXRBcHBTdGF0ZTogKCkgPT4gQXBwU3RhdGVcbiAgc2V0QXBwU3RhdGU6IChmOiAocHJldjogQXBwU3RhdGUpID0+IEFwcFN0YXRlKSA9PiB2b2lkXG4gIHNpZ25hbDogQWJvcnRTaWduYWxcbiAgb25TZXNzaW9uUmVhZHk/OiAobXNnOiBzdHJpbmcpID0+IHZvaWRcbn0pOiBQcm9taXNlPHZvaWQ+IHtcbiAgY29uc3QgeyBibHVyYiwgc2VlZFBsYW4sIGdldEFwcFN0YXRlLCBzZXRBcHBTdGF0ZSwgc2lnbmFsLCBvblNlc3Npb25SZWFkeSB9ID1cbiAgICBvcHRzXG4gIC8vIEhvaXN0ZWQgc28gdGhlIGNhdGNoIGJsb2NrIGNhbiBhcmNoaXZlIHRoZSByZW1vdGUgc2Vzc2lvbiBpZiBhbiBlcnJvclxuICAvLyBvY2N1cnMgYWZ0ZXIgdGVsZXBvcnRUb1JlbW90ZSBzdWNjZWVkcyAoYXZvaWRzIDMwbWluIG9ycGhhbikuXG4gIGxldCBzZXNzaW9uSWQ6IHN0cmluZyB8IHVuZGVmaW5lZFxuICB0cnkge1xuICAgIGNvbnN0IG1vZGVsID0gZ2V0VWx0cmFwbGFuTW9kZWwoKVxuXG4gICAgY29uc3QgZWxpZ2liaWxpdHkgPSBhd2FpdCBjaGVja1JlbW90ZUFnZW50RWxpZ2liaWxpdHkoKVxuICAgIGlmICghZWxpZ2liaWxpdHkuZWxpZ2libGUpIHtcbiAgICAgIGxvZ0V2ZW50KCd0ZW5ndV91bHRyYXBsYW5fY3JlYXRlX2ZhaWxlZCcsIHtcbiAgICAgICAgcmVhc29uOlxuICAgICAgICAgICdwcmVjb25kaXRpb24nIGFzIEFuYWx5dGljc01ldGFkYXRhX0lfVkVSSUZJRURfVEhJU19JU19OT1RfQ09ERV9PUl9GSUxFUEFUSFMsXG4gICAgICAgIHByZWNvbmRpdGlvbl9lcnJvcnM6IGVsaWdpYmlsaXR5LmVycm9yc1xuICAgICAgICAgIC5tYXAoZSA9PiBlLnR5cGUpXG4gICAgICAgICAgLmpvaW4oXG4gICAgICAgICAgICAnLCcsXG4gICAgICAgICAgKSBhcyBBbmFseXRpY3NNZXRhZGF0YV9JX1ZFUklGSUVEX1RISVNfSVNfTk9UX0NPREVfT1JfRklMRVBBVEhTLFxuICAgICAgfSlcbiAgICAgIGNvbnN0IHJlYXNvbnMgPSBlbGlnaWJpbGl0eS5lcnJvcnMubWFwKGZvcm1hdFByZWNvbmRpdGlvbkVycm9yKS5qb2luKCdcXG4nKVxuICAgICAgZW5xdWV1ZVBlbmRpbmdOb3RpZmljYXRpb24oe1xuICAgICAgICB2YWx1ZTogYHVsdHJhcGxhbjogY2Fubm90IGxhdW5jaCByZW1vdGUgc2Vzc2lvbiDigJRcXG4ke3JlYXNvbnN9YCxcbiAgICAgICAgbW9kZTogJ3Rhc2stbm90aWZpY2F0aW9uJyxcbiAgICAgIH0pXG4gICAgICByZXR1cm5cbiAgICB9XG5cbiAgICBjb25zdCBwcm9tcHQgPSBidWlsZFVsdHJhcGxhblByb21wdChibHVyYiwgc2VlZFBsYW4pXG4gICAgbGV0IGJ1bmRsZUZhaWxNc2c6IHN0cmluZyB8IHVuZGVmaW5lZFxuICAgIGNvbnN0IHNlc3Npb24gPSBhd2FpdCB0ZWxlcG9ydFRvUmVtb3RlKHtcbiAgICAgIGluaXRpYWxNZXNzYWdlOiBwcm9tcHQsXG4gICAgICBkZXNjcmlwdGlvbjogYmx1cmIgfHwgJ1JlZmluZSBsb2NhbCBwbGFuJyxcbiAgICAgIG1vZGVsLFxuICAgICAgcGVybWlzc2lvbk1vZGU6ICdwbGFuJyxcbiAgICAgIHVsdHJhcGxhbjogdHJ1ZSxcbiAgICAgIHNpZ25hbCxcbiAgICAgIHVzZURlZmF1bHRFbnZpcm9ubWVudDogdHJ1ZSxcbiAgICAgIG9uQnVuZGxlRmFpbDogbXNnID0+IHtcbiAgICAgICAgYnVuZGxlRmFpbE1zZyA9IG1zZ1xuICAgICAgfSxcbiAgICB9KVxuICAgIGlmICghc2Vzc2lvbikge1xuICAgICAgbG9nRXZlbnQoJ3Rlbmd1X3VsdHJhcGxhbl9jcmVhdGVfZmFpbGVkJywge1xuICAgICAgICByZWFzb246IChidW5kbGVGYWlsTXNnXG4gICAgICAgICAgPyAnYnVuZGxlX2ZhaWwnXG4gICAgICAgICAgOiAndGVsZXBvcnRfbnVsbCcpIGFzIEFuYWx5dGljc01ldGFkYXRhX0lfVkVSSUZJRURfVEhJU19JU19OT1RfQ09ERV9PUl9GSUxFUEFUSFMsXG4gICAgICB9KVxuICAgICAgZW5xdWV1ZVBlbmRpbmdOb3RpZmljYXRpb24oe1xuICAgICAgICB2YWx1ZTogYHVsdHJhcGxhbjogc2Vzc2lvbiBjcmVhdGlvbiBmYWlsZWQke2J1bmRsZUZhaWxNc2cgPyBgIOKAlCAke2J1bmRsZUZhaWxNc2d9YCA6ICcnfS4gU2VlIC0tZGVidWcgZm9yIGRldGFpbHMuYCxcbiAgICAgICAgbW9kZTogJ3Rhc2stbm90aWZpY2F0aW9uJyxcbiAgICAgIH0pXG4gICAgICByZXR1cm5cbiAgICB9XG4gICAgc2Vzc2lvbklkID0gc2Vzc2lvbi5pZFxuXG4gICAgY29uc3QgdXJsID0gZ2V0UmVtb3RlU2Vzc2lvblVybChzZXNzaW9uLmlkLCBwcm9jZXNzLmVudi5TRVNTSU9OX0lOR1JFU1NfVVJMKVxuICAgIHNldEFwcFN0YXRlKHByZXYgPT4gKHtcbiAgICAgIC4uLnByZXYsXG4gICAgICB1bHRyYXBsYW5TZXNzaW9uVXJsOiB1cmwsXG4gICAgICB1bHRyYXBsYW5MYXVuY2hpbmc6IHVuZGVmaW5lZCxcbiAgICB9KSlcbiAgICBvblNlc3Npb25SZWFkeT8uKGJ1aWxkU2Vzc2lvblJlYWR5TWVzc2FnZSh1cmwpKVxuICAgIGxvZ0V2ZW50KCd0ZW5ndV91bHRyYXBsYW5fbGF1bmNoZWQnLCB7XG4gICAgICBoYXNfc2VlZF9wbGFuOiBCb29sZWFuKHNlZWRQbGFuKSxcbiAgICAgIG1vZGVsOlxuICAgICAgICBtb2RlbCBhcyBBbmFseXRpY3NNZXRhZGF0YV9JX1ZFUklGSUVEX1RISVNfSVNfTk9UX0NPREVfT1JfRklMRVBBVEhTLFxuICAgIH0pXG4gICAgLy8gVE9ETygjMjM5ODUpOiByZXBsYWNlIHJlZ2lzdGVyUmVtb3RlQWdlbnRUYXNrICsgc3RhcnREZXRhY2hlZFBvbGwgd2l0aFxuICAgIC8vIEV4aXRQbGFuTW9kZVNjYW5uZXIgaW5zaWRlIHN0YXJ0UmVtb3RlU2Vzc2lvblBvbGxpbmcuXG4gICAgY29uc3QgeyB0YXNrSWQgfSA9IHJlZ2lzdGVyUmVtb3RlQWdlbnRUYXNrKHtcbiAgICAgIHJlbW90ZVRhc2tUeXBlOiAndWx0cmFwbGFuJyxcbiAgICAgIHNlc3Npb246IHsgaWQ6IHNlc3Npb24uaWQsIHRpdGxlOiBibHVyYiB8fCAnVWx0cmFwbGFuJyB9LFxuICAgICAgY29tbWFuZDogYmx1cmIsXG4gICAgICBjb250ZXh0OiB7XG4gICAgICAgIGFib3J0Q29udHJvbGxlcjogbmV3IEFib3J0Q29udHJvbGxlcigpLFxuICAgICAgICBnZXRBcHBTdGF0ZSxcbiAgICAgICAgc2V0QXBwU3RhdGUsXG4gICAgICB9LFxuICAgICAgaXNVbHRyYXBsYW46IHRydWUsXG4gICAgfSlcbiAgICBzdGFydERldGFjaGVkUG9sbCh0YXNrSWQsIHNlc3Npb24uaWQsIHVybCwgZ2V0QXBwU3RhdGUsIHNldEFwcFN0YXRlKVxuICB9IGNhdGNoIChlKSB7XG4gICAgbG9nRXJyb3IoZSlcbiAgICBsb2dFdmVudCgndGVuZ3VfdWx0cmFwbGFuX2NyZWF0ZV9mYWlsZWQnLCB7XG4gICAgICByZWFzb246XG4gICAgICAgICd1bmV4cGVjdGVkX2Vycm9yJyBhcyBBbmFseXRpY3NNZXRhZGF0YV9JX1ZFUklGSUVEX1RISVNfSVNfTk9UX0NPREVfT1JfRklMRVBBVEhTLFxuICAgIH0pXG4gICAgZW5xdWV1ZVBlbmRpbmdOb3RpZmljYXRpb24oe1xuICAgICAgdmFsdWU6IGB1bHRyYXBsYW46IHVuZXhwZWN0ZWQgZXJyb3Ig4oCUICR7ZXJyb3JNZXNzYWdlKGUpfWAsXG4gICAgICBtb2RlOiAndGFzay1ub3RpZmljYXRpb24nLFxuICAgIH0pXG4gICAgaWYgKHNlc3Npb25JZCkge1xuICAgICAgLy8gRXJyb3IgYWZ0ZXIgdGVsZXBvcnQgc3VjY2VlZGVkIOKAlCBhcmNoaXZlIHNvIHRoZSByZW1vdGUgZG9lc24ndCBzaXRcbiAgICAgIC8vIHJ1bm5pbmcgZm9yIDMwbWluIHdpdGggbm9ib2R5IHBvbGxpbmcgaXQuXG4gICAgICB2b2lkIGFyY2hpdmVSZW1vdGVTZXNzaW9uKHNlc3Npb25JZCkuY2F0Y2goZXJyID0+XG4gICAgICAgIGxvZ0ZvckRlYnVnZ2luZygndWx0cmFwbGFuOiBmYWlsZWQgdG8gYXJjaGl2ZSBvcnBoYW5lZCBzZXNzaW9uJywgZXJyKSxcbiAgICAgIClcbiAgICAgIC8vIHVsdHJhcGxhblNlc3Npb25VcmwgbWF5IGhhdmUgYmVlbiBzZXQgYmVmb3JlIHRoZSB0aHJvdzsgY2xlYXIgaXQgc29cbiAgICAgIC8vIHRoZSBcImFscmVhZHkgcG9sbGluZ1wiIGd1YXJkIGRvZXNuJ3QgYmxvY2sgZnV0dXJlIGxhdW5jaGVzLlxuICAgICAgc2V0QXBwU3RhdGUocHJldiA9PlxuICAgICAgICBwcmV2LnVsdHJhcGxhblNlc3Npb25VcmxcbiAgICAgICAgICA/IHsgLi4ucHJldiwgdWx0cmFwbGFuU2Vzc2lvblVybDogdW5kZWZpbmVkIH1cbiAgICAgICAgICA6IHByZXYsXG4gICAgICApXG4gICAgfVxuICB9IGZpbmFsbHkge1xuICAgIC8vIE5vLW9wIG9uIHN1Y2Nlc3M6IHRoZSB1cmwtc2V0dGluZyBzZXRBcHBTdGF0ZSBhbHJlYWR5IGNsZWFyZWQgdGhpcy5cbiAgICBzZXRBcHBTdGF0ZShwcmV2ID0+XG4gICAgICBwcmV2LnVsdHJhcGxhbkxhdW5jaGluZ1xuICAgICAgICA/IHsgLi4ucHJldiwgdWx0cmFwbGFuTGF1bmNoaW5nOiB1bmRlZmluZWQgfVxuICAgICAgICA6IHByZXYsXG4gICAgKVxuICB9XG59XG5cbmNvbnN0IGNhbGw6IExvY2FsSlNYQ29tbWFuZENhbGwgPSBhc3luYyAob25Eb25lLCBjb250ZXh0LCBhcmdzKSA9PiB7XG4gIGNvbnN0IGJsdXJiID0gYXJncy50cmltKClcblxuICAvLyBCYXJlIC91bHRyYXBsYW4gKG5vIGFyZ3MsIG5vIHNlZWQgcGxhbikganVzdCBzaG93cyB1c2FnZSDigJQgbm8gZGlhbG9nLlxuICBpZiAoIWJsdXJiKSB7XG4gICAgY29uc3QgbXNnID0gYXdhaXQgbGF1bmNoVWx0cmFwbGFuKHtcbiAgICAgIGJsdXJiLFxuICAgICAgZ2V0QXBwU3RhdGU6IGNvbnRleHQuZ2V0QXBwU3RhdGUsXG4gICAgICBzZXRBcHBTdGF0ZTogY29udGV4dC5zZXRBcHBTdGF0ZSxcbiAgICAgIHNpZ25hbDogY29udGV4dC5hYm9ydENvbnRyb2xsZXIuc2lnbmFsLFxuICAgIH0pXG4gICAgb25Eb25lKG1zZywgeyBkaXNwbGF5OiAnc3lzdGVtJyB9KVxuICAgIHJldHVybiBudWxsXG4gIH1cblxuICAvLyBHdWFyZCBtYXRjaGVzIGxhdW5jaFVsdHJhcGxhbidzIG93biBjaGVjayDigJQgc2hvd2luZyB0aGUgZGlhbG9nIHdoZW4gYVxuICAvLyBzZXNzaW9uIGlzIGFscmVhZHkgYWN0aXZlIG9yIGxhdW5jaGluZyB3b3VsZCB3YXN0ZSB0aGUgdXNlcidzIGNsaWNrIGFuZCBzZXRcbiAgLy8gaGFzU2VlblVsdHJhcGxhblRlcm1zIGJlZm9yZSB0aGUgbGF1bmNoIGZhaWxzLlxuICBjb25zdCB7IHVsdHJhcGxhblNlc3Npb25Vcmw6IGFjdGl2ZSwgdWx0cmFwbGFuTGF1bmNoaW5nIH0gPVxuICAgIGNvbnRleHQuZ2V0QXBwU3RhdGUoKVxuICBpZiAoYWN0aXZlIHx8IHVsdHJhcGxhbkxhdW5jaGluZykge1xuICAgIGxvZ0V2ZW50KCd0ZW5ndV91bHRyYXBsYW5fY3JlYXRlX2ZhaWxlZCcsIHtcbiAgICAgIHJlYXNvbjogKGFjdGl2ZVxuICAgICAgICA/ICdhbHJlYWR5X3BvbGxpbmcnXG4gICAgICAgIDogJ2FscmVhZHlfbGF1bmNoaW5nJykgYXMgQW5hbHl0aWNzTWV0YWRhdGFfSV9WRVJJRklFRF9USElTX0lTX05PVF9DT0RFX09SX0ZJTEVQQVRIUyxcbiAgICB9KVxuICAgIG9uRG9uZShidWlsZEFscmVhZHlBY3RpdmVNZXNzYWdlKGFjdGl2ZSksIHsgZGlzcGxheTogJ3N5c3RlbScgfSlcbiAgICByZXR1cm4gbnVsbFxuICB9XG5cbiAgLy8gTW91bnQgdGhlIHByZS1sYXVuY2ggZGlhbG9nIHZpYSBmb2N1c2VkSW5wdXREaWFsb2cgKGJvdHRvbSByZWdpb24sIGxpa2VcbiAgLy8gcGVybWlzc2lvbiBkaWFsb2dzKSByYXRoZXIgdGhhbiByZXR1cm5pbmcgSlNYICh0cmFuc2NyaXB0IGFyZWEsIGFuY2hvcnNcbiAgLy8gYXQgdG9wIG9mIHNjcm9sbGJhY2spLiBSRVBMLnRzeCBoYW5kbGVzIGxhdW5jaC9jbGVhci9jYW5jZWwgb24gY2hvaWNlLlxuICBjb250ZXh0LnNldEFwcFN0YXRlKHByZXYgPT4gKHsgLi4ucHJldiwgdWx0cmFwbGFuTGF1bmNoUGVuZGluZzogeyBibHVyYiB9IH0pKVxuICAvLyAnc2tpcCcgc3VwcHJlc3NlcyB0aGUgKG5vIGNvbnRlbnQpIGVjaG8g4oCUIHRoZSBkaWFsb2cncyBjaG9pY2UgaGFuZGxlclxuICAvLyBhZGRzIHRoZSByZWFsIC91bHRyYXBsYW4gZWNobyArIGxhdW5jaCBjb25maXJtYXRpb24uXG4gIG9uRG9uZSh1bmRlZmluZWQsIHsgZGlzcGxheTogJ3NraXAnIH0pXG4gIHJldHVybiBudWxsXG59XG5cbmV4cG9ydCBkZWZhdWx0IHtcbiAgdHlwZTogJ2xvY2FsLWpzeCcsXG4gIG5hbWU6ICd1bHRyYXBsYW4nLFxuICBkZXNjcmlwdGlvbjogYH4xMOKAkzMwIG1pbiDCtyBDbGF1ZGUgQ29kZSBvbiB0aGUgd2ViIGRyYWZ0cyBhbiBhZHZhbmNlZCBwbGFuIHlvdSBjYW4gZWRpdCBhbmQgYXBwcm92ZS4gU2VlICR7Q0NSX1RFUk1TX1VSTH1gLFxuICBhcmd1bWVudEhpbnQ6ICc8cHJvbXB0PicsXG4gIGlzRW5hYmxlZDogKCkgPT4gXCJleHRlcm5hbFwiID09PSAnYW50JyxcbiAgbG9hZDogKCkgPT4gUHJvbWlzZS5yZXNvbHZlKHsgY2FsbCB9KSxcbn0gc2F0aXNmaWVzIENvbW1hbmRcbiJdLCJtYXBwaW5ncyI6IkFBQUEsU0FBU0EsWUFBWSxRQUFRLElBQUk7QUFDakMsU0FBU0MsK0JBQStCLFFBQVEsb0JBQW9CO0FBQ3BFLGNBQWNDLE9BQU8sUUFBUSxnQkFBZ0I7QUFDN0MsU0FBU0MsWUFBWSxRQUFRLHlCQUF5QjtBQUN0RCxTQUFTQyxtQkFBbUIsUUFBUSx5QkFBeUI7QUFDN0QsU0FBU0MsbUNBQW1DLFFBQVEscUNBQXFDO0FBQ3pGLFNBQ0UsS0FBS0MsMERBQTBELEVBQy9EQyxRQUFRLFFBQ0gsZ0NBQWdDO0FBQ3ZDLGNBQWNDLFFBQVEsUUFBUSwyQkFBMkI7QUFDekQsU0FDRUMsMkJBQTJCLEVBQzNCQyx1QkFBdUIsRUFDdkJDLGVBQWUsRUFDZixLQUFLQyxvQkFBb0IsRUFDekJDLHVCQUF1QixRQUNsQiw2Q0FBNkM7QUFDcEQsY0FBY0MsbUJBQW1CLFFBQVEscUJBQXFCO0FBQzlELFNBQVNDLGVBQWUsUUFBUSxtQkFBbUI7QUFDbkQsU0FBU0MsWUFBWSxRQUFRLG9CQUFvQjtBQUNqRCxTQUFTQyxRQUFRLFFBQVEsaUJBQWlCO0FBQzFDLFNBQVNDLDBCQUEwQixRQUFRLGlDQUFpQztBQUM1RSxTQUFTQyxpQkFBaUIsUUFBUSwyQkFBMkI7QUFDN0QsU0FBU0MsZUFBZSxRQUFRLDRCQUE0QjtBQUM1RCxTQUFTQyxvQkFBb0IsRUFBRUMsZ0JBQWdCLFFBQVEsc0JBQXNCO0FBQzdFLFNBQ0VDLDJCQUEyQixFQUMzQkMsa0JBQWtCLFFBQ2Isa0NBQWtDOztBQUV6QztBQUNBOztBQUVBO0FBQ0EsTUFBTUMsb0JBQW9CLEdBQUcsRUFBRSxHQUFHLEVBQUUsR0FBRyxJQUFJO0FBRTNDLE9BQU8sTUFBTUMsYUFBYSxHQUN4Qix3REFBd0Q7O0FBRTFEO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSxTQUFTQyxpQkFBaUJBLENBQUEsQ0FBRSxFQUFFLE1BQU0sQ0FBQztFQUNuQyxPQUFPdEIsbUNBQW1DLENBQ3hDLHVCQUF1QixFQUN2QmMsaUJBQWlCLENBQUNTLE1BQU0sQ0FBQ0MsVUFDM0IsQ0FBQztBQUNIOztBQUVBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsTUFBTUMsVUFBVSxHQUFHQyxPQUFPLENBQUMsK0JBQStCLENBQUM7QUFDM0Q7QUFDQSxNQUFNQyxvQkFBb0IsRUFBRSxNQUFNLEdBQUcsQ0FDbkMsT0FBT0YsVUFBVSxLQUFLLFFBQVEsR0FBR0EsVUFBVSxHQUFHQSxVQUFVLENBQUNHLE9BQU8sRUFDaEVDLE9BQU8sQ0FBQyxDQUFDOztBQUVYO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBLE1BQU1DLHNCQUFzQixFQUFFLE1BQU0sR0FDbEMsVUFBVSxLQUFLLEtBQUssSUFBSUMsT0FBTyxDQUFDQyxHQUFHLENBQUNDLHFCQUFxQixHQUNyRHRDLFlBQVksQ0FBQ29DLE9BQU8sQ0FBQ0MsR0FBRyxDQUFDQyxxQkFBcUIsRUFBRSxNQUFNLENBQUMsQ0FBQ0osT0FBTyxDQUFDLENBQUMsR0FDakVGLG9CQUFvQjtBQUMxQjs7QUFFQTtBQUNBO0FBQ0E7QUFDQTtBQUNBLE9BQU8sU0FBU08sb0JBQW9CQSxDQUFDQyxLQUFLLEVBQUUsTUFBTSxFQUFFQyxRQUFpQixDQUFSLEVBQUUsTUFBTSxDQUFDLEVBQUUsTUFBTSxDQUFDO0VBQzdFLE1BQU1DLEtBQUssRUFBRSxNQUFNLEVBQUUsR0FBRyxFQUFFO0VBQzFCLElBQUlELFFBQVEsRUFBRTtJQUNaQyxLQUFLLENBQUNDLElBQUksQ0FBQyxpQ0FBaUMsRUFBRSxFQUFFLEVBQUVGLFFBQVEsRUFBRSxFQUFFLENBQUM7RUFDakU7RUFDQUMsS0FBSyxDQUFDQyxJQUFJLENBQUNSLHNCQUFzQixDQUFDO0VBQ2xDLElBQUlLLEtBQUssRUFBRTtJQUNURSxLQUFLLENBQUNDLElBQUksQ0FBQyxFQUFFLEVBQUVILEtBQUssQ0FBQztFQUN2QjtFQUNBLE9BQU9FLEtBQUssQ0FBQ0UsSUFBSSxDQUFDLElBQUksQ0FBQztBQUN6QjtBQUVBLFNBQVNDLGlCQUFpQkEsQ0FDeEJDLE1BQU0sRUFBRSxNQUFNLEVBQ2RDLFNBQVMsRUFBRSxNQUFNLEVBQ2pCQyxHQUFHLEVBQUUsTUFBTSxFQUNYQyxXQUFXLEVBQUUsR0FBRyxHQUFHekMsUUFBUSxFQUMzQjBDLFdBQVcsRUFBRSxDQUFDQyxDQUFDLEVBQUUsQ0FBQ0MsSUFBSSxFQUFFNUMsUUFBUSxFQUFFLEdBQUdBLFFBQVEsRUFBRSxHQUFHLElBQUksQ0FDdkQsRUFBRSxJQUFJLENBQUM7RUFDTixNQUFNNkMsT0FBTyxHQUFHQyxJQUFJLENBQUNDLEdBQUcsQ0FBQyxDQUFDO0VBQzFCLElBQUlDLE1BQU0sR0FBRyxLQUFLO0VBQ2xCLEtBQUssQ0FBQyxZQUFZO0lBQ2hCLElBQUk7TUFDRixNQUFNO1FBQUVDLElBQUk7UUFBRUMsV0FBVztRQUFFQztNQUFnQixDQUFDLEdBQzFDLE1BQU1wQywyQkFBMkIsQ0FDL0J3QixTQUFTLEVBQ1R0QixvQkFBb0IsRUFDcEJtQyxLQUFLLElBQUk7UUFDUCxJQUFJQSxLQUFLLEtBQUssYUFBYSxFQUN6QnJELFFBQVEsQ0FBQyxnQ0FBZ0MsRUFBRSxDQUFDLENBQUMsQ0FBQztRQUNoRGEsZUFBZSxDQUFDUixvQkFBb0IsQ0FBQyxDQUFDa0MsTUFBTSxFQUFFSSxXQUFXLEVBQUVXLENBQUMsSUFBSTtVQUM5RCxJQUFJQSxDQUFDLENBQUNDLE1BQU0sS0FBSyxTQUFTLEVBQUUsT0FBT0QsQ0FBQztVQUNwQyxNQUFNRSxJQUFJLEdBQUdILEtBQUssS0FBSyxTQUFTLEdBQUdJLFNBQVMsR0FBR0osS0FBSztVQUNwRCxPQUFPQyxDQUFDLENBQUNJLGNBQWMsS0FBS0YsSUFBSSxHQUM1QkYsQ0FBQyxHQUNEO1lBQUUsR0FBR0EsQ0FBQztZQUFFSSxjQUFjLEVBQUVGO1VBQUssQ0FBQztRQUNwQyxDQUFDLENBQUM7TUFDSixDQUFDLEVBQ0QsTUFBTWQsV0FBVyxDQUFDLENBQUMsQ0FBQ2lCLEtBQUssR0FBR3BCLE1BQU0sQ0FBQyxFQUFFZ0IsTUFBTSxLQUFLLFNBQ2xELENBQUM7TUFDSHZELFFBQVEsQ0FBQywwQkFBMEIsRUFBRTtRQUNuQzRELFdBQVcsRUFBRWIsSUFBSSxDQUFDQyxHQUFHLENBQUMsQ0FBQyxHQUFHRixPQUFPO1FBQ2pDZSxXQUFXLEVBQUVYLElBQUksQ0FBQ1ksTUFBTTtRQUN4QkMsWUFBWSxFQUFFWixXQUFXO1FBQ3pCYSxnQkFBZ0IsRUFDZFosZUFBZSxJQUFJckQ7TUFDdkIsQ0FBQyxDQUFDO01BQ0YsSUFBSXFELGVBQWUsS0FBSyxRQUFRLEVBQUU7UUFDaEM7UUFDQTtRQUNBO1FBQ0E7UUFDQTtRQUNBLE1BQU1hLElBQUksR0FBR3ZCLFdBQVcsQ0FBQyxDQUFDLENBQUNpQixLQUFLLEdBQUdwQixNQUFNLENBQUM7UUFDMUMsSUFBSTBCLElBQUksRUFBRVYsTUFBTSxLQUFLLFNBQVMsRUFBRTtRQUNoQzFDLGVBQWUsQ0FBQ1Isb0JBQW9CLENBQUMsQ0FBQ2tDLE1BQU0sRUFBRUksV0FBVyxFQUFFVyxDQUFDLElBQzFEQSxDQUFDLENBQUNDLE1BQU0sS0FBSyxTQUFTLEdBQ2xCRCxDQUFDLEdBQ0Q7VUFBRSxHQUFHQSxDQUFDO1VBQUVDLE1BQU0sRUFBRSxXQUFXO1VBQUVXLE9BQU8sRUFBRW5CLElBQUksQ0FBQ0MsR0FBRyxDQUFDO1FBQUUsQ0FDdkQsQ0FBQztRQUNETCxXQUFXLENBQUNFLElBQUksSUFDZEEsSUFBSSxDQUFDc0IsbUJBQW1CLEtBQUsxQixHQUFHLEdBQzVCO1VBQUUsR0FBR0ksSUFBSTtVQUFFc0IsbUJBQW1CLEVBQUVWO1FBQVUsQ0FBQyxHQUMzQ1osSUFDTixDQUFDO1FBQ0RsQywwQkFBMEIsQ0FBQztVQUN6QnlELEtBQUssRUFBRSxDQUNMLDhFQUE4RTNCLEdBQUcsRUFBRSxFQUNuRixFQUFFLEVBQ0Ysb0dBQW9HLENBQ3JHLENBQUNKLElBQUksQ0FBQyxJQUFJLENBQUM7VUFDWmdDLElBQUksRUFBRTtRQUNSLENBQUMsQ0FBQztNQUNKLENBQUMsTUFBTTtRQUNMO1FBQ0E7UUFDQTtRQUNBO1FBQ0ExQixXQUFXLENBQUNFLElBQUksSUFBSTtVQUNsQixNQUFNb0IsSUFBSSxHQUFHcEIsSUFBSSxDQUFDYyxLQUFLLEdBQUdwQixNQUFNLENBQUM7VUFDakMsSUFBSSxDQUFDMEIsSUFBSSxJQUFJQSxJQUFJLENBQUNWLE1BQU0sS0FBSyxTQUFTLEVBQUUsT0FBT1YsSUFBSTtVQUNuRCxPQUFPO1lBQ0wsR0FBR0EsSUFBSTtZQUNQeUIsc0JBQXNCLEVBQUU7Y0FBRXBCLElBQUk7Y0FBRVYsU0FBUztjQUFFRDtZQUFPO1VBQ3BELENBQUM7UUFDSCxDQUFDLENBQUM7TUFDSjtJQUNGLENBQUMsQ0FBQyxPQUFPZ0MsQ0FBQyxFQUFFO01BQ1Y7TUFDQTtNQUNBO01BQ0EsTUFBTU4sSUFBSSxHQUFHdkIsV0FBVyxDQUFDLENBQUMsQ0FBQ2lCLEtBQUssR0FBR3BCLE1BQU0sQ0FBQztNQUMxQyxJQUFJMEIsSUFBSSxFQUFFVixNQUFNLEtBQUssU0FBUyxFQUFFO01BQ2hDTixNQUFNLEdBQUcsSUFBSTtNQUNiakQsUUFBUSxDQUFDLHdCQUF3QixFQUFFO1FBQ2pDNEQsV0FBVyxFQUFFYixJQUFJLENBQUNDLEdBQUcsQ0FBQyxDQUFDLEdBQUdGLE9BQU87UUFDakMwQixNQUFNLEVBQUUsQ0FBQ0QsQ0FBQyxZQUFZdEQsa0JBQWtCLEdBQ3BDc0QsQ0FBQyxDQUFDQyxNQUFNLEdBQ1Isb0JBQW9CLEtBQUt6RSwwREFBMEQ7UUFDdkZnRSxZQUFZLEVBQ1ZRLENBQUMsWUFBWXRELGtCQUFrQixHQUFHc0QsQ0FBQyxDQUFDcEIsV0FBVyxHQUFHTTtNQUN0RCxDQUFDLENBQUM7TUFDRjlDLDBCQUEwQixDQUFDO1FBQ3pCeUQsS0FBSyxFQUFFLHFCQUFxQjNELFlBQVksQ0FBQzhELENBQUMsQ0FBQyxnQkFBZ0I5QixHQUFHLEVBQUU7UUFDaEU0QixJQUFJLEVBQUU7TUFDUixDQUFDLENBQUM7TUFDRjtNQUNBO01BQ0EsS0FBS3ZELG9CQUFvQixDQUFDMEIsU0FBUyxDQUFDLENBQUNpQyxLQUFLLENBQUNGLENBQUMsSUFDMUMvRCxlQUFlLENBQUMsNkJBQTZCa0UsTUFBTSxDQUFDSCxDQUFDLENBQUMsRUFBRSxDQUMxRCxDQUFDO01BQ0Q1QixXQUFXLENBQUNFLElBQUk7TUFDZDtNQUNBO01BQ0FBLElBQUksQ0FBQ3NCLG1CQUFtQixLQUFLMUIsR0FBRyxHQUM1QjtRQUFFLEdBQUdJLElBQUk7UUFBRXNCLG1CQUFtQixFQUFFVjtNQUFVLENBQUMsR0FDM0NaLElBQ04sQ0FBQztJQUNILENBQUMsU0FBUztNQUNSO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBLElBQUlJLE1BQU0sRUFBRTtRQUNWcEMsZUFBZSxDQUFDUixvQkFBb0IsQ0FBQyxDQUFDa0MsTUFBTSxFQUFFSSxXQUFXLEVBQUVXLENBQUMsSUFDMURBLENBQUMsQ0FBQ0MsTUFBTSxLQUFLLFNBQVMsR0FDbEJELENBQUMsR0FDRDtVQUFFLEdBQUdBLENBQUM7VUFBRUMsTUFBTSxFQUFFLFFBQVE7VUFBRVcsT0FBTyxFQUFFbkIsSUFBSSxDQUFDQyxHQUFHLENBQUM7UUFBRSxDQUNwRCxDQUFDO01BQ0g7SUFDRjtFQUNGLENBQUMsRUFBRSxDQUFDO0FBQ047O0FBRUE7QUFDQTtBQUNBLFNBQVMyQixrQkFBa0JBLENBQUNDLGtCQUE0QixDQUFULEVBQUUsT0FBTyxDQUFDLEVBQUUsTUFBTSxDQUFDO0VBQ2hFLE1BQU1DLE1BQU0sR0FBR0Qsa0JBQWtCLEdBQUcsR0FBR2xGLCtCQUErQixHQUFHLEdBQUcsRUFBRTtFQUM5RSxPQUFPLEdBQUdFLFlBQVksZUFBZWlGLE1BQU0sa0NBQWtDO0FBQy9FO0FBRUEsU0FBU0Msd0JBQXdCQSxDQUFDckMsR0FBRyxFQUFFLE1BQU0sQ0FBQyxFQUFFLE1BQU0sQ0FBQztFQUNyRCxPQUFPLEdBQUc3QyxZQUFZLDJEQUEyRDZDLEdBQUcseUNBQXlDN0MsWUFBWSxpQ0FBaUM7QUFDNUs7QUFFQSxTQUFTbUYseUJBQXlCQSxDQUFDdEMsR0FBRyxFQUFFLE1BQU0sR0FBRyxTQUFTLENBQUMsRUFBRSxNQUFNLENBQUM7RUFDbEUsT0FBT0EsR0FBRyxHQUNOLG9DQUFvQ0EsR0FBRyxzREFBc0QsR0FDN0YscUVBQXFFO0FBQzNFOztBQUVBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsT0FBTyxlQUFldUMsYUFBYUEsQ0FDakN6QyxNQUFNLEVBQUUsTUFBTSxFQUNkQyxTQUFTLEVBQUUsTUFBTSxFQUNqQkcsV0FBVyxFQUFFLENBQUNDLENBQUMsRUFBRSxDQUFDQyxJQUFJLEVBQUU1QyxRQUFRLEVBQUUsR0FBR0EsUUFBUSxFQUFFLEdBQUcsSUFBSSxDQUN2RCxFQUFFZ0YsT0FBTyxDQUFDLElBQUksQ0FBQyxDQUFDO0VBQ2Y7RUFDQTtFQUNBLE1BQU03RSxlQUFlLENBQUM4RSxJQUFJLENBQUMzQyxNQUFNLEVBQUVJLFdBQVcsQ0FBQztFQUMvQ0EsV0FBVyxDQUFDRSxJQUFJLElBQ2RBLElBQUksQ0FBQ3NCLG1CQUFtQixJQUN4QnRCLElBQUksQ0FBQ3lCLHNCQUFzQixJQUMzQnpCLElBQUksQ0FBQ3NDLGtCQUFrQixHQUNuQjtJQUNFLEdBQUd0QyxJQUFJO0lBQ1BzQixtQkFBbUIsRUFBRVYsU0FBUztJQUM5QmEsc0JBQXNCLEVBQUViLFNBQVM7SUFDakMwQixrQkFBa0IsRUFBRTFCO0VBQ3RCLENBQUMsR0FDRFosSUFDTixDQUFDO0VBQ0QsTUFBTUosR0FBRyxHQUFHNUMsbUJBQW1CLENBQUMyQyxTQUFTLEVBQUVYLE9BQU8sQ0FBQ0MsR0FBRyxDQUFDc0QsbUJBQW1CLENBQUM7RUFDM0V6RSwwQkFBMEIsQ0FBQztJQUN6QnlELEtBQUssRUFBRSxrQ0FBa0MzQixHQUFHLEVBQUU7SUFDOUM0QixJQUFJLEVBQUU7RUFDUixDQUFDLENBQUM7RUFDRjFELDBCQUEwQixDQUFDO0lBQ3pCeUQsS0FBSyxFQUNILHNIQUFzSDtJQUN4SEMsSUFBSSxFQUFFLG1CQUFtQjtJQUN6QmdCLE1BQU0sRUFBRTtFQUNWLENBQUMsQ0FBQztBQUNKOztBQUVBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBLE9BQU8sZUFBZUMsZUFBZUEsQ0FBQ0MsSUFBSSxFQUFFO0VBQzFDdEQsS0FBSyxFQUFFLE1BQU07RUFDYkMsUUFBUSxDQUFDLEVBQUUsTUFBTTtFQUNqQlEsV0FBVyxFQUFFLEdBQUcsR0FBR3pDLFFBQVE7RUFDM0IwQyxXQUFXLEVBQUUsQ0FBQ0MsQ0FBQyxFQUFFLENBQUNDLElBQUksRUFBRTVDLFFBQVEsRUFBRSxHQUFHQSxRQUFRLEVBQUUsR0FBRyxJQUFJO0VBQ3REdUYsTUFBTSxFQUFFQyxXQUFXO0VBQ25CO0VBQ0FiLGtCQUFrQixDQUFDLEVBQUUsT0FBTztFQUM1QjtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFYyxjQUFjLENBQUMsRUFBRSxDQUFDQyxHQUFHLEVBQUUsTUFBTSxFQUFFLEdBQUcsSUFBSTtBQUN4QyxDQUFDLENBQUMsRUFBRVYsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDO0VBQ2xCLE1BQU07SUFDSmhELEtBQUs7SUFDTEMsUUFBUTtJQUNSUSxXQUFXO0lBQ1hDLFdBQVc7SUFDWDZDLE1BQU07SUFDTlosa0JBQWtCO0lBQ2xCYztFQUNGLENBQUMsR0FBR0gsSUFBSTtFQUVSLE1BQU07SUFBRXBCLG1CQUFtQixFQUFFeUIsTUFBTTtJQUFFVDtFQUFtQixDQUFDLEdBQUd6QyxXQUFXLENBQUMsQ0FBQztFQUN6RSxJQUFJa0QsTUFBTSxJQUFJVCxrQkFBa0IsRUFBRTtJQUNoQ25GLFFBQVEsQ0FBQywrQkFBK0IsRUFBRTtNQUN4Q3dFLE1BQU0sRUFBRSxDQUFDb0IsTUFBTSxHQUNYLGlCQUFpQixHQUNqQixtQkFBbUIsS0FBSzdGO0lBQzlCLENBQUMsQ0FBQztJQUNGLE9BQU9nRix5QkFBeUIsQ0FBQ2EsTUFBTSxDQUFDO0VBQzFDO0VBRUEsSUFBSSxDQUFDM0QsS0FBSyxJQUFJLENBQUNDLFFBQVEsRUFBRTtJQUN2QjtJQUNBLE9BQU87SUFDTDtJQUNBO0lBQ0EsaUVBQWlFLEVBQ2pFLGdCQUFnQixFQUNoQixFQUFFLEVBQ0YsNkRBQTZELEVBQzdELGlFQUFpRSxFQUNqRSw2REFBNkQsRUFDN0QsNkNBQTZDLEVBQzdDLGtCQUFrQixFQUNsQixFQUFFLEVBQ0YsVUFBVWYsYUFBYSxFQUFFLENBQzFCLENBQUNrQixJQUFJLENBQUMsSUFBSSxDQUFDO0VBQ2Q7O0VBRUE7RUFDQTtFQUNBTSxXQUFXLENBQUNFLElBQUksSUFDZEEsSUFBSSxDQUFDc0Msa0JBQWtCLEdBQUd0QyxJQUFJLEdBQUc7SUFBRSxHQUFHQSxJQUFJO0lBQUVzQyxrQkFBa0IsRUFBRTtFQUFLLENBQ3ZFLENBQUM7RUFDRCxLQUFLVSxjQUFjLENBQUM7SUFDbEI1RCxLQUFLO0lBQ0xDLFFBQVE7SUFDUlEsV0FBVztJQUNYQyxXQUFXO0lBQ1g2QyxNQUFNO0lBQ05FO0VBQ0YsQ0FBQyxDQUFDO0VBQ0YsT0FBT2Ysa0JBQWtCLENBQUNDLGtCQUFrQixDQUFDO0FBQy9DO0FBRUEsZUFBZWlCLGNBQWNBLENBQUNOLElBQUksRUFBRTtFQUNsQ3RELEtBQUssRUFBRSxNQUFNO0VBQ2JDLFFBQVEsQ0FBQyxFQUFFLE1BQU07RUFDakJRLFdBQVcsRUFBRSxHQUFHLEdBQUd6QyxRQUFRO0VBQzNCMEMsV0FBVyxFQUFFLENBQUNDLENBQUMsRUFBRSxDQUFDQyxJQUFJLEVBQUU1QyxRQUFRLEVBQUUsR0FBR0EsUUFBUSxFQUFFLEdBQUcsSUFBSTtFQUN0RHVGLE1BQU0sRUFBRUMsV0FBVztFQUNuQkMsY0FBYyxDQUFDLEVBQUUsQ0FBQ0MsR0FBRyxFQUFFLE1BQU0sRUFBRSxHQUFHLElBQUk7QUFDeEMsQ0FBQyxDQUFDLEVBQUVWLE9BQU8sQ0FBQyxJQUFJLENBQUMsQ0FBQztFQUNoQixNQUFNO0lBQUVoRCxLQUFLO0lBQUVDLFFBQVE7SUFBRVEsV0FBVztJQUFFQyxXQUFXO0lBQUU2QyxNQUFNO0lBQUVFO0VBQWUsQ0FBQyxHQUN6RUgsSUFBSTtFQUNOO0VBQ0E7RUFDQSxJQUFJL0MsU0FBUyxFQUFFLE1BQU0sR0FBRyxTQUFTO0VBQ2pDLElBQUk7SUFDRixNQUFNc0QsS0FBSyxHQUFHMUUsaUJBQWlCLENBQUMsQ0FBQztJQUVqQyxNQUFNMkUsV0FBVyxHQUFHLE1BQU03RiwyQkFBMkIsQ0FBQyxDQUFDO0lBQ3ZELElBQUksQ0FBQzZGLFdBQVcsQ0FBQ0MsUUFBUSxFQUFFO01BQ3pCaEcsUUFBUSxDQUFDLCtCQUErQixFQUFFO1FBQ3hDd0UsTUFBTSxFQUNKLGNBQWMsSUFBSXpFLDBEQUEwRDtRQUM5RWtHLG1CQUFtQixFQUFFRixXQUFXLENBQUNHLE1BQU0sQ0FDcENDLEdBQUcsQ0FBQzVCLENBQUMsSUFBSUEsQ0FBQyxDQUFDNkIsSUFBSSxDQUFDLENBQ2hCL0QsSUFBSSxDQUNILEdBQ0YsQ0FBQyxJQUFJdEM7TUFDVCxDQUFDLENBQUM7TUFDRixNQUFNc0csT0FBTyxHQUFHTixXQUFXLENBQUNHLE1BQU0sQ0FBQ0MsR0FBRyxDQUFDaEcsdUJBQXVCLENBQUMsQ0FBQ2tDLElBQUksQ0FBQyxJQUFJLENBQUM7TUFDMUUxQiwwQkFBMEIsQ0FBQztRQUN6QnlELEtBQUssRUFBRSw4Q0FBOENpQyxPQUFPLEVBQUU7UUFDOURoQyxJQUFJLEVBQUU7TUFDUixDQUFDLENBQUM7TUFDRjtJQUNGO0lBRUEsTUFBTWlDLE1BQU0sR0FBR3RFLG9CQUFvQixDQUFDQyxLQUFLLEVBQUVDLFFBQVEsQ0FBQztJQUNwRCxJQUFJcUUsYUFBYSxFQUFFLE1BQU0sR0FBRyxTQUFTO0lBQ3JDLE1BQU1DLE9BQU8sR0FBRyxNQUFNekYsZ0JBQWdCLENBQUM7TUFDckMwRixjQUFjLEVBQUVILE1BQU07TUFDdEJJLFdBQVcsRUFBRXpFLEtBQUssSUFBSSxtQkFBbUI7TUFDekM2RCxLQUFLO01BQ0xhLGNBQWMsRUFBRSxNQUFNO01BQ3RCQyxTQUFTLEVBQUUsSUFBSTtNQUNmcEIsTUFBTTtNQUNOcUIscUJBQXFCLEVBQUUsSUFBSTtNQUMzQkMsWUFBWSxFQUFFbkIsR0FBRyxJQUFJO1FBQ25CWSxhQUFhLEdBQUdaLEdBQUc7TUFDckI7SUFDRixDQUFDLENBQUM7SUFDRixJQUFJLENBQUNhLE9BQU8sRUFBRTtNQUNaeEcsUUFBUSxDQUFDLCtCQUErQixFQUFFO1FBQ3hDd0UsTUFBTSxFQUFFLENBQUMrQixhQUFhLEdBQ2xCLGFBQWEsR0FDYixlQUFlLEtBQUt4RztNQUMxQixDQUFDLENBQUM7TUFDRlksMEJBQTBCLENBQUM7UUFDekJ5RCxLQUFLLEVBQUUscUNBQXFDbUMsYUFBYSxHQUFHLE1BQU1BLGFBQWEsRUFBRSxHQUFHLEVBQUUsNEJBQTRCO1FBQ2xIbEMsSUFBSSxFQUFFO01BQ1IsQ0FBQyxDQUFDO01BQ0Y7SUFDRjtJQUNBN0IsU0FBUyxHQUFHZ0UsT0FBTyxDQUFDTyxFQUFFO0lBRXRCLE1BQU10RSxHQUFHLEdBQUc1QyxtQkFBbUIsQ0FBQzJHLE9BQU8sQ0FBQ08sRUFBRSxFQUFFbEYsT0FBTyxDQUFDQyxHQUFHLENBQUNzRCxtQkFBbUIsQ0FBQztJQUM1RXpDLFdBQVcsQ0FBQ0UsSUFBSSxLQUFLO01BQ25CLEdBQUdBLElBQUk7TUFDUHNCLG1CQUFtQixFQUFFMUIsR0FBRztNQUN4QjBDLGtCQUFrQixFQUFFMUI7SUFDdEIsQ0FBQyxDQUFDLENBQUM7SUFDSGlDLGNBQWMsR0FBR1osd0JBQXdCLENBQUNyQyxHQUFHLENBQUMsQ0FBQztJQUMvQ3pDLFFBQVEsQ0FBQywwQkFBMEIsRUFBRTtNQUNuQ2dILGFBQWEsRUFBRUMsT0FBTyxDQUFDL0UsUUFBUSxDQUFDO01BQ2hDNEQsS0FBSyxFQUNIQSxLQUFLLElBQUkvRjtJQUNiLENBQUMsQ0FBQztJQUNGO0lBQ0E7SUFDQSxNQUFNO01BQUV3QztJQUFPLENBQUMsR0FBR2pDLHVCQUF1QixDQUFDO01BQ3pDNEcsY0FBYyxFQUFFLFdBQVc7TUFDM0JWLE9BQU8sRUFBRTtRQUFFTyxFQUFFLEVBQUVQLE9BQU8sQ0FBQ08sRUFBRTtRQUFFSSxLQUFLLEVBQUVsRixLQUFLLElBQUk7TUFBWSxDQUFDO01BQ3hEbUYsT0FBTyxFQUFFbkYsS0FBSztNQUNkb0YsT0FBTyxFQUFFO1FBQ1BDLGVBQWUsRUFBRSxJQUFJQyxlQUFlLENBQUMsQ0FBQztRQUN0QzdFLFdBQVc7UUFDWEM7TUFDRixDQUFDO01BQ0Q2RSxXQUFXLEVBQUU7SUFDZixDQUFDLENBQUM7SUFDRmxGLGlCQUFpQixDQUFDQyxNQUFNLEVBQUVpRSxPQUFPLENBQUNPLEVBQUUsRUFBRXRFLEdBQUcsRUFBRUMsV0FBVyxFQUFFQyxXQUFXLENBQUM7RUFDdEUsQ0FBQyxDQUFDLE9BQU80QixDQUFDLEVBQUU7SUFDVjdELFFBQVEsQ0FBQzZELENBQUMsQ0FBQztJQUNYdkUsUUFBUSxDQUFDLCtCQUErQixFQUFFO01BQ3hDd0UsTUFBTSxFQUNKLGtCQUFrQixJQUFJekU7SUFDMUIsQ0FBQyxDQUFDO0lBQ0ZZLDBCQUEwQixDQUFDO01BQ3pCeUQsS0FBSyxFQUFFLGlDQUFpQzNELFlBQVksQ0FBQzhELENBQUMsQ0FBQyxFQUFFO01BQ3pERixJQUFJLEVBQUU7SUFDUixDQUFDLENBQUM7SUFDRixJQUFJN0IsU0FBUyxFQUFFO01BQ2I7TUFDQTtNQUNBLEtBQUsxQixvQkFBb0IsQ0FBQzBCLFNBQVMsQ0FBQyxDQUFDaUMsS0FBSyxDQUFDZ0QsR0FBRyxJQUM1Q2pILGVBQWUsQ0FBQywrQ0FBK0MsRUFBRWlILEdBQUcsQ0FDdEUsQ0FBQztNQUNEO01BQ0E7TUFDQTlFLFdBQVcsQ0FBQ0UsSUFBSSxJQUNkQSxJQUFJLENBQUNzQixtQkFBbUIsR0FDcEI7UUFBRSxHQUFHdEIsSUFBSTtRQUFFc0IsbUJBQW1CLEVBQUVWO01BQVUsQ0FBQyxHQUMzQ1osSUFDTixDQUFDO0lBQ0g7RUFDRixDQUFDLFNBQVM7SUFDUjtJQUNBRixXQUFXLENBQUNFLElBQUksSUFDZEEsSUFBSSxDQUFDc0Msa0JBQWtCLEdBQ25CO01BQUUsR0FBR3RDLElBQUk7TUFBRXNDLGtCQUFrQixFQUFFMUI7SUFBVSxDQUFDLEdBQzFDWixJQUNOLENBQUM7RUFDSDtBQUNGO0FBRUEsTUFBTTZFLElBQUksRUFBRW5ILG1CQUFtQixHQUFHLE1BQUFtSCxDQUFPQyxNQUFNLEVBQUVOLE9BQU8sRUFBRU8sSUFBSSxLQUFLO0VBQ2pFLE1BQU0zRixLQUFLLEdBQUcyRixJQUFJLENBQUNDLElBQUksQ0FBQyxDQUFDOztFQUV6QjtFQUNBLElBQUksQ0FBQzVGLEtBQUssRUFBRTtJQUNWLE1BQU0wRCxHQUFHLEdBQUcsTUFBTUwsZUFBZSxDQUFDO01BQ2hDckQsS0FBSztNQUNMUyxXQUFXLEVBQUUyRSxPQUFPLENBQUMzRSxXQUFXO01BQ2hDQyxXQUFXLEVBQUUwRSxPQUFPLENBQUMxRSxXQUFXO01BQ2hDNkMsTUFBTSxFQUFFNkIsT0FBTyxDQUFDQyxlQUFlLENBQUM5QjtJQUNsQyxDQUFDLENBQUM7SUFDRm1DLE1BQU0sQ0FBQ2hDLEdBQUcsRUFBRTtNQUFFbUMsT0FBTyxFQUFFO0lBQVMsQ0FBQyxDQUFDO0lBQ2xDLE9BQU8sSUFBSTtFQUNiOztFQUVBO0VBQ0E7RUFDQTtFQUNBLE1BQU07SUFBRTNELG1CQUFtQixFQUFFeUIsTUFBTTtJQUFFVDtFQUFtQixDQUFDLEdBQ3ZEa0MsT0FBTyxDQUFDM0UsV0FBVyxDQUFDLENBQUM7RUFDdkIsSUFBSWtELE1BQU0sSUFBSVQsa0JBQWtCLEVBQUU7SUFDaENuRixRQUFRLENBQUMsK0JBQStCLEVBQUU7TUFDeEN3RSxNQUFNLEVBQUUsQ0FBQ29CLE1BQU0sR0FDWCxpQkFBaUIsR0FDakIsbUJBQW1CLEtBQUs3RjtJQUM5QixDQUFDLENBQUM7SUFDRjRILE1BQU0sQ0FBQzVDLHlCQUF5QixDQUFDYSxNQUFNLENBQUMsRUFBRTtNQUFFa0MsT0FBTyxFQUFFO0lBQVMsQ0FBQyxDQUFDO0lBQ2hFLE9BQU8sSUFBSTtFQUNiOztFQUVBO0VBQ0E7RUFDQTtFQUNBVCxPQUFPLENBQUMxRSxXQUFXLENBQUNFLElBQUksS0FBSztJQUFFLEdBQUdBLElBQUk7SUFBRWtGLHNCQUFzQixFQUFFO01BQUU5RjtJQUFNO0VBQUUsQ0FBQyxDQUFDLENBQUM7RUFDN0U7RUFDQTtFQUNBMEYsTUFBTSxDQUFDbEUsU0FBUyxFQUFFO0lBQUVxRSxPQUFPLEVBQUU7RUFBTyxDQUFDLENBQUM7RUFDdEMsT0FBTyxJQUFJO0FBQ2IsQ0FBQztBQUVELGVBQWU7RUFDYjFCLElBQUksRUFBRSxXQUFXO0VBQ2pCNEIsSUFBSSxFQUFFLFdBQVc7RUFDakJ0QixXQUFXLEVBQUUsNkZBQTZGdkYsYUFBYSxFQUFFO0VBQ3pIOEcsWUFBWSxFQUFFLFVBQVU7RUFDeEJDLFNBQVMsRUFBRUEsQ0FBQSxLQUFNLFVBQVUsS0FBSyxLQUFLO0VBQ3JDQyxJQUFJLEVBQUVBLENBQUEsS0FBTWxELE9BQU8sQ0FBQ21ELE9BQU8sQ0FBQztJQUFFVjtFQUFLLENBQUM7QUFDdEMsQ0FBQyxXQUFXL0gsT0FBTyIsImlnbm9yZUxpc3QiOltdfQ==
+  load: () => Promise.resolve({ call }),
+} satisfies Command

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -761,7 +761,7 @@ function PromptInput({
     if (feature('ULTRAPLAN') && ultraplanTriggers.length) {
       addNotification({
         key: 'ultraplan-active',
-        text: 'This prompt will launch an ultraplan session in Claude Code on the web',
+        text: 'This prompt will launch a local ultraplan session in a new terminal',
         priority: 'immediate',
         timeoutMs: 5000
       });

--- a/src/components/UltraplanChoiceDialog.tsx
+++ b/src/components/UltraplanChoiceDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Box, Text } from '../ink.js'
 import { Select } from './CustomSelect/index.js'
 import { Dialog } from './design-system/Dialog.js'
@@ -13,8 +13,21 @@ import {
   prepareUserContent,
 } from '../utils/messages.js'
 import { updateTaskState } from '../utils/task/framework.js'
+import {
+  formatUltraplanArtifactPreview,
+  listUltraplanArtifacts,
+  readUltraplanArtifact,
+  type UltraplanArtifactKey,
+} from '../utils/ultraplan/artifactPreview.js'
 
-type UltraplanChoice = 'insert' | 'save' | 'dismiss'
+type UltraplanChoice =
+  | 'preview-plan'
+  | 'preview-workspace'
+  | 'preview-stdout'
+  | 'preview-stderr'
+  | 'insert'
+  | 'save'
+  | 'dismiss'
 
 type Props = {
   plan: string
@@ -33,9 +46,64 @@ export function UltraplanChoiceDialog({
   setMessages,
 }: Props): React.ReactNode {
   const setAppState = useSetAppState()
+  const artifactDescriptors = useMemo(
+    () => listUltraplanArtifacts(sessionId),
+    [sessionId],
+  )
+  const [selectedArtifact, setSelectedArtifact] =
+    useState<UltraplanArtifactKey>('plan')
+  const [artifactContents, setArtifactContents] = useState<
+    Partial<Record<UltraplanArtifactKey, string | null>>
+  >({
+    plan,
+  })
+
+  useEffect(() => {
+    let disposed = false
+    if (selectedArtifact === 'plan') {
+      setArtifactContents(prev =>
+        prev.plan === plan
+          ? prev
+          : {
+              ...prev,
+              plan,
+            },
+      )
+      return
+    }
+
+    void readUltraplanArtifact(sessionId, selectedArtifact).then(content => {
+      if (disposed) return
+      setArtifactContents(prev => ({
+        ...prev,
+        [selectedArtifact]: content,
+      }))
+    })
+
+    return () => {
+      disposed = true
+    }
+  }, [plan, selectedArtifact, sessionId])
 
   const handleChoice = useCallback(
     (choice: UltraplanChoice) => {
+      if (choice === 'preview-plan') {
+        setSelectedArtifact('plan')
+        return
+      }
+      if (choice === 'preview-workspace') {
+        setSelectedArtifact('workspaceSnapshot')
+        return
+      }
+      if (choice === 'preview-stdout') {
+        setSelectedArtifact('stdout')
+        return
+      }
+      if (choice === 'preview-stderr') {
+        setSelectedArtifact('stderr')
+        return
+      }
+
       if (choice === 'insert') {
         setMessages(prev => [
           ...prev,
@@ -69,13 +137,23 @@ export function UltraplanChoiceDialog({
         ...prev,
         ultraplanPendingChoice: undefined,
         ultraplanSessionUrl: undefined,
-      }))
+        }))
     },
     [plan, sessionId, taskId, setMessages, setAppState],
   )
 
-  const displayPlan =
-    plan.length > 2000 ? plan.slice(0, 2000) + '\n\n... (truncated)' : plan
+  const currentArtifact =
+    artifactDescriptors.find(item => item.key === selectedArtifact) ??
+    artifactDescriptors[0]
+  const currentContent =
+    selectedArtifact === 'plan'
+      ? artifactContents.plan ?? plan
+      : artifactContents[selectedArtifact] ?? null
+  const displayPreview = formatUltraplanArtifactPreview(
+    selectedArtifact,
+    currentContent,
+    2400,
+  )
 
   return (
     <Dialog
@@ -84,19 +162,43 @@ export function UltraplanChoiceDialog({
     >
       <Box flexDirection="column" gap={1}>
         <Text dimColor>Local artifact: {sessionId}</Text>
+        <Text dimColor>
+          Viewing: {currentArtifact?.label ?? 'Artifact'}{' '}
+          {currentArtifact ? `(${currentArtifact.filename})` : ''}
+        </Text>
         <Box
           flexDirection="column"
           borderStyle="single"
           borderColor="gray"
           paddingX={1}
-          height={Math.min(displayPlan.split('\n').length + 2, 20)}
+          height={Math.min(displayPreview.split('\n').length + 2, 20)}
           overflow="hidden"
         >
-          <Text>{displayPlan}</Text>
+          <Text>{displayPreview}</Text>
         </Box>
       </Box>
       <Select
         options={[
+          {
+            value: 'preview-plan' as const,
+            label: 'Preview plan',
+            description: 'View the generated plan.md artifact',
+          },
+          {
+            value: 'preview-workspace' as const,
+            label: 'Preview snapshot',
+            description: 'View the workspace-snapshot.md artifact',
+          },
+          {
+            value: 'preview-stdout' as const,
+            label: 'Preview stdout',
+            description: 'View the planner stdout.log artifact',
+          },
+          {
+            value: 'preview-stderr' as const,
+            label: 'Preview stderr',
+            description: 'View the planner stderr.log artifact',
+          },
           {
             value: 'insert' as const,
             label: 'Insert plan here',

--- a/src/components/UltraplanChoiceDialog.tsx
+++ b/src/components/UltraplanChoiceDialog.tsx
@@ -13,7 +13,9 @@ import {
   prepareUserContent,
 } from '../utils/messages.js'
 import { updateTaskState } from '../utils/task/framework.js'
+import { openPath } from '../utils/browser.js'
 import {
+  buildUltraplanArtifactMessage,
   formatUltraplanArtifactPreview,
   listUltraplanArtifacts,
   readUltraplanArtifact,
@@ -25,6 +27,8 @@ type UltraplanChoice =
   | 'preview-workspace'
   | 'preview-stdout'
   | 'preview-stderr'
+  | 'insert-current'
+  | 'open-run-dir'
   | 'insert'
   | 'save'
   | 'dismiss'
@@ -86,7 +90,7 @@ export function UltraplanChoiceDialog({
   }, [plan, selectedArtifact, sessionId])
 
   const handleChoice = useCallback(
-    (choice: UltraplanChoice) => {
+    async (choice: UltraplanChoice) => {
       if (choice === 'preview-plan') {
         setSelectedArtifact('plan')
         return
@@ -102,6 +106,39 @@ export function UltraplanChoiceDialog({
       if (choice === 'preview-stderr') {
         setSelectedArtifact('stderr')
         return
+      }
+      if (choice === 'open-run-dir') {
+        const ok = await openPath(sessionId)
+        setMessages(prev => [
+          ...prev,
+          createSystemMessage(
+            ok
+              ? `Opened Ultraplan run directory: ${sessionId}`
+              : `Failed to open Ultraplan run directory: ${sessionId}`,
+            ok ? 'info' : 'warning',
+          ),
+        ])
+        return
+      }
+      if (choice === 'insert-current') {
+        const injected =
+          selectedArtifact === 'plan'
+            ? plan
+            : buildUltraplanArtifactMessage(
+                selectedArtifact,
+                sessionId,
+                artifactContents[selectedArtifact] ?? currentContent,
+              )
+        setMessages(prev => [
+          ...prev,
+          createSystemMessage(
+            `Ultraplan finished. Inserting ${currentArtifact?.label ?? 'artifact'} into this session.`,
+            'info',
+          ),
+          createUserMessage({
+            content: prepareUserContent({ inputString: injected }),
+          }),
+        ])
       }
 
       if (choice === 'insert') {
@@ -126,6 +163,8 @@ export function UltraplanChoiceDialog({
               summary:
                 choice === 'insert'
                   ? 'Plan inserted into the session'
+                  : choice === 'insert-current'
+                    ? `${currentArtifact?.label ?? 'Artifact'} inserted into the session`
                   : choice === 'save'
                     ? `Plan kept on disk: ${sessionId}`
                     : 'Plan dismissed',
@@ -137,9 +176,19 @@ export function UltraplanChoiceDialog({
         ...prev,
         ultraplanPendingChoice: undefined,
         ultraplanSessionUrl: undefined,
-        }))
+      }))
     },
-    [plan, sessionId, taskId, setMessages, setAppState],
+    [
+      artifactContents,
+      currentArtifact?.label,
+      currentContent,
+      plan,
+      selectedArtifact,
+      sessionId,
+      taskId,
+      setMessages,
+      setAppState,
+    ],
   )
 
   const currentArtifact =
@@ -203,6 +252,16 @@ export function UltraplanChoiceDialog({
             value: 'insert' as const,
             label: 'Insert plan here',
             description: 'Send the local plan back into this session',
+          },
+          {
+            value: 'insert-current' as const,
+            label: 'Insert current artifact',
+            description: 'Send the currently previewed artifact into this session',
+          },
+          {
+            value: 'open-run-dir' as const,
+            label: 'Open run dir',
+            description: 'Open the local Ultraplan artifact folder in your OS',
           },
           {
             value: 'save' as const,

--- a/src/components/UltraplanChoiceDialog.tsx
+++ b/src/components/UltraplanChoiceDialog.tsx
@@ -5,7 +5,7 @@ import { Dialog } from './design-system/Dialog.js'
 import type { AppState } from '../state/AppStateStore.js'
 import { useSetAppState } from '../state/AppState.js'
 import type { Message } from '../types/message.js'
-import type { RemoteAgentTaskState } from '../tasks/RemoteAgentTask/RemoteAgentTask.js'
+import type { LocalWorkflowTaskState } from '../tasks/LocalWorkflowTask/LocalWorkflowTask.js'
 import type { FileStateCache } from '../utils/fileStateCache.js'
 import {
   createUserMessage,
@@ -13,10 +13,8 @@ import {
   prepareUserContent,
 } from '../utils/messages.js'
 import { updateTaskState } from '../utils/task/framework.js'
-import { archiveRemoteSession } from '../utils/teleport.js'
-import { logForDebugging } from '../utils/debug.js'
 
-type UltraplanChoice = 'execute' | 'dismiss'
+type UltraplanChoice = 'insert' | 'save' | 'dismiss'
 
 type Props = {
   plan: string
@@ -38,11 +36,11 @@ export function UltraplanChoiceDialog({
 
   const handleChoice = useCallback(
     (choice: UltraplanChoice) => {
-      if (choice === 'execute') {
+      if (choice === 'insert') {
         setMessages(prev => [
           ...prev,
           createSystemMessage(
-            'Ultraplan approved. Executing the following plan:',
+            'Ultraplan finished. Inserting the local plan into this session.',
             'info',
           ),
           createUserMessage({
@@ -51,24 +49,27 @@ export function UltraplanChoiceDialog({
         ])
       }
 
-      // Mark task completed
-      updateTaskState<RemoteAgentTaskState>(taskId, setAppState, t =>
-        t.status !== 'running'
+      updateTaskState<LocalWorkflowTaskState>(taskId, setAppState, t =>
+        t.status === 'completed'
           ? t
-          : { ...t, status: 'completed', endTime: Date.now() },
+          : {
+              ...t,
+              status: 'completed',
+              summary:
+                choice === 'insert'
+                  ? 'Plan inserted into the session'
+                  : choice === 'save'
+                    ? `Plan kept on disk: ${sessionId}`
+                    : 'Plan dismissed',
+              endTime: Date.now(),
+            },
       )
 
-      // Clear ultraplan state
       setAppState(prev => ({
         ...prev,
         ultraplanPendingChoice: undefined,
         ultraplanSessionUrl: undefined,
       }))
-
-      // Archive the remote session
-      void archiveRemoteSession(sessionId).catch(e =>
-        logForDebugging(`ultraplan choice archive failed: ${String(e)}`),
-      )
     },
     [plan, sessionId, taskId, setMessages, setAppState],
   )
@@ -82,6 +83,7 @@ export function UltraplanChoiceDialog({
       onCancel={() => handleChoice('dismiss')}
     >
       <Box flexDirection="column" gap={1}>
+        <Text dimColor>Local artifact: {sessionId}</Text>
         <Box
           flexDirection="column"
           borderStyle="single"
@@ -96,15 +98,19 @@ export function UltraplanChoiceDialog({
       <Select
         options={[
           {
-            value: 'execute' as const,
-            label: 'Execute plan here',
-            description:
-              'Send the plan to Claude for execution in this session',
+            value: 'insert' as const,
+            label: 'Insert plan here',
+            description: 'Send the local plan back into this session',
+          },
+          {
+            value: 'save' as const,
+            label: 'Save only',
+            description: 'Keep the artifact on disk without injecting it',
           },
           {
             value: 'dismiss' as const,
             label: 'Dismiss',
-            description: 'Discard the plan',
+            description: 'Close this dialog and discard the result here',
           },
         ]}
         onChange={(value: UltraplanChoice) => handleChoice(value)}

--- a/src/components/UltraplanLaunchDialog.tsx
+++ b/src/components/UltraplanLaunchDialog.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Box, Text } from '../ink.js'
 import { Select } from './CustomSelect/index.js'
 import { Dialog } from './design-system/Dialog.js'
-import { CCR_TERMS_URL } from '../commands/ultraplan.js'
 
 type UltraplanLaunchChoice = 'launch' | 'cancel'
 
@@ -21,17 +20,19 @@ export function UltraplanLaunchDialog({ onChoice }: Props): React.ReactNode {
     >
       <Box flexDirection="column" gap={1}>
         <Text>
-          This will start a remote Claude Code session on the web to draft an
-          advanced plan using Opus. The plan typically takes 10–30 minutes.
-          Your terminal stays free while it works.
+          This will open a new local terminal and start a planning-only
+          freecode session for deep repo analysis.
         </Text>
-        <Text dimColor>Terms: {CCR_TERMS_URL}</Text>
+        <Text dimColor>
+          It will write a local plan artifact first. You can then insert that
+          plan back into this conversation.
+        </Text>
       </Box>
       <Select
         options={[
           {
             value: 'launch' as const,
-            label: 'Launch ultraplan',
+            label: 'Launch local ultraplan',
           },
           {
             value: 'cancel' as const,

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -730,7 +730,7 @@ export function buildPlanApprovalOptions({
   });
   if (showUltraplan) {
     options.push({
-      label: 'No, refine with Ultraplan on Claude Code on the web',
+      label: 'No, refine with local Ultraplan',
       value: 'ultraplan'
     });
   }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -4855,6 +4855,7 @@ export function REPL({
 
                 {feature('ULTRAPLAN') ? focusedInputDialog === 'ultraplan-launch' && ultraplanLaunchPending && <UltraplanLaunchDialog onChoice={(choice, opts) => {
             const blurb = ultraplanLaunchPending.blurb;
+            const profile = ultraplanLaunchPending.profile ?? 'deep';
             setAppState(prev => prev.ultraplanLaunchPending ? {
               ...prev,
               ultraplanLaunchPending: undefined
@@ -4863,7 +4864,7 @@ export function REPL({
             // Command's onDone used display:'skip', so add the
             // echo here — gives immediate feedback before the
             // ~5s teleportToRemote resolves.
-            setMessages(prev => [...prev, createCommandInputMessage(formatCommandInputTags('ultraplan', blurb))]);
+            setMessages(prev => [...prev, createCommandInputMessage(formatCommandInputTags('ultraplan', profile === 'deep' ? blurb : `--${profile} ${blurb}`.trim()))]);
             const appendStdout = (msg: string) => setMessages(prev => [...prev, createCommandInputMessage(`<${LOCAL_COMMAND_STDOUT_TAG}>${escapeXml(msg)}</${LOCAL_COMMAND_STDOUT_TAG}>`)]);
             // Defer the second message if a query is mid-turn
             // so it lands after the assistant reply, not
@@ -4885,6 +4886,7 @@ export function REPL({
             };
             void launchUltraplan({
               blurb,
+              profile,
               getAppState: () => store.getState(),
               setAppState,
               signal: createAbortController().signal,

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -277,6 +277,7 @@ const launchUltraplan: typeof import('../commands/ultraplan.js').launchUltraplan
 import { IssueFlagBanner } from '../components/PromptInput/IssueFlagBanner.js';
 import { useIssueFlagBanner } from '../hooks/useIssueFlagBanner.js';
 import { CompanionSprite, CompanionFloatingBubble, MIN_COLS_FOR_FULL_SPRITE } from '../buddy/CompanionSprite.js';
+import { fireCompanionObserver } from '../buddy/observer.js';
 import { DevBar } from '../components/DevBar.js';
 // Session manager removed - using AppState now
 import type { RemoteSessionConfig } from '../remote/RemoteSessionManager.js';

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -11,7 +11,7 @@ import {
   getAnthropicApiKey,
   getApiKeyFromApiKeyHelper,
   getClaudeAIOAuthTokens,
-  getCodexOAuthTokens,
+  getCodexAuthToken,
   isClaudeAISubscriber,
   isCodexSubscriber,
   refreshAndGetAwsCredentials,
@@ -307,9 +307,9 @@ export async function getAnthropicClient({
 
   // ── Codex (OpenAI) provider via fetch adapter ─────────────────────
   if (isCodexSubscriber()) {
-    const codexTokens = getCodexOAuthTokens()
-    if (codexTokens?.accessToken) {
-      const codexFetch = createCodexFetch(codexTokens.accessToken)
+    const codexAuthToken = getCodexAuthToken()
+    if (codexAuthToken) {
+      const codexFetch = createCodexFetch(codexAuthToken)
       const clientConfig: ConstructorParameters<typeof Anthropic>[0] = {
         apiKey: 'codex-placeholder', // SDK requires a key but the fetch adapter handles auth
         ...ARGS,

--- a/src/services/api/codex-fetch-adapter.ts
+++ b/src/services/api/codex-fetch-adapter.ts
@@ -15,7 +15,7 @@
  * Endpoint: https://chatgpt.com/backend-api/codex/responses
  */
 
-import { getCodexOAuthTokens } from '../../utils/auth.js'
+import { getCodexApiKey, getCodexAuthToken } from '../../utils/auth.js'
 
 // ── Available Codex models ──────────────────────────────────────────
 export const CODEX_MODELS = [
@@ -736,7 +736,25 @@ async function translateCodexStreamToAnthropic(
 
 // ── Main fetch interceptor ──────────────────────────────────────────
 
-const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex/responses'
+const DEFAULT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex/responses'
+
+function getCodexBaseUrl(): string {
+  const configured =
+    process.env.OPENAI_BASE_URL ||
+    process.env.CLAUDE_CODE_OPENAI_BASE_URL ||
+    process.env.CODEX_BASE_URL
+
+  if (!configured) {
+    return DEFAULT_CODEX_BASE_URL
+  }
+
+  const trimmed = configured.replace(/\/+$/, '')
+  return trimmed.endsWith('/responses') ? trimmed : `${trimmed}/responses`
+}
+
+function isJwtLikeToken(token: string): boolean {
+  return token.split('.').length === 3
+}
 
 /**
  * Creates a fetch function that intercepts Anthropic API calls and routes them to Codex.
@@ -746,8 +764,6 @@ const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex/responses'
 export function createCodexFetch(
   accessToken: string,
 ): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
-  const accountId = extractAccountId(accessToken)
-
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = input instanceof Request ? input.url : String(input)
 
@@ -771,25 +787,51 @@ export function createCodexFetch(
     }
 
     // Get current token (may have been refreshed)
-    const tokens = getCodexOAuthTokens()
-    const currentToken = tokens?.accessToken || accessToken
+    const currentToken = getCodexAuthToken() || accessToken
+    const usingApiKey = !!getCodexApiKey()
+    const shouldAttachOpenAIOAuthHeaders = !usingApiKey && isJwtLikeToken(currentToken)
+    const accountId = shouldAttachOpenAIOAuthHeaders
+      ? extractAccountId(currentToken)
+      : null
 
     // Translate to Codex format
     const { codexBody, codexModel } = translateToCodexBody(anthropicBody)
+    const targetUrl = getCodexBaseUrl()
+    if (process.env.SORUX_DEBUG === '1') {
+      console.error(
+        '[codex-fetch]',
+        JSON.stringify({
+          requestUrl: url,
+          targetUrl,
+          anthropicModel: anthropicBody.model,
+          codexModel,
+          hasTools: Array.isArray(codexBody.tools) ? codexBody.tools.length : 0,
+          stream: codexBody.stream,
+        }),
+      )
+    }
 
     // Call Codex API
-    const codexResponse = await globalThis.fetch(CODEX_BASE_URL, {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+      Authorization: `Bearer ${currentToken}`,
+    }
+
+    if (shouldAttachOpenAIOAuthHeaders && accountId) {
+      headers['chatgpt-account-id'] = accountId
+      headers.originator = 'pi'
+      headers['OpenAI-Beta'] = 'responses=experimental'
+    }
+
+    const codexResponse = await globalThis.fetch(targetUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'text/event-stream',
-        Authorization: `Bearer ${currentToken}`,
-        'chatgpt-account-id': accountId,
-        originator: 'pi',
-        'OpenAI-Beta': 'responses=experimental',
-      },
+      headers,
       body: JSON.stringify(codexBody),
     })
+    if (process.env.SORUX_DEBUG === '1') {
+      console.error('[codex-fetch-status]', codexResponse.status, targetUrl)
+    }
 
     if (!codexResponse.ok) {
       const errorText = await codexResponse.text()

--- a/src/state/AppStateStore.ts
+++ b/src/state/AppStateStore.ts
@@ -426,16 +426,13 @@ export type AppState = DeepImmutable<{
   // Effort value
   effortValue?: EffortValue
   // Set synchronously in launchUltraplan before the detached flow starts.
-  // Prevents duplicate launches during the ~5s window before
-  // ultraplanSessionUrl is set by teleportToRemote. Cleared by launchDetached
-  // once the URL is set or on failure.
+  // Prevents duplicate launches before the local run directory marker is set.
   ultraplanLaunching?: boolean
-  // Active ultraplan CCR session URL. Set while the RemoteAgentTask runs;
-  // truthy disables the keyword trigger + rainbow. Cleared when the poll
-  // reaches terminal state.
+  // Active local ultraplan run marker (`local:<runDir>`). Truthy disables the
+  // keyword trigger and launch hint until the run reaches a terminal state.
   ultraplanSessionUrl?: string
-  // Approved ultraplan awaiting user choice (implement here vs fresh session).
-  // Set by RemoteAgentTask poll on approval; cleared by UltraplanChoiceDialog.
+  // Finished local ultraplan awaiting user choice. Cleared by
+  // UltraplanChoiceDialog.
   ultraplanPendingChoice?: { plan: string; sessionId: string; taskId: string }
   // Pre-launch permission dialog. Set by /ultraplan (slash or keyword);
   // cleared by UltraplanLaunchDialog on choice.

--- a/src/state/AppStateStore.ts
+++ b/src/state/AppStateStore.ts
@@ -436,7 +436,7 @@ export type AppState = DeepImmutable<{
   ultraplanPendingChoice?: { plan: string; sessionId: string; taskId: string }
   // Pre-launch permission dialog. Set by /ultraplan (slash or keyword);
   // cleared by UltraplanLaunchDialog on choice.
-  ultraplanLaunchPending?: { blurb: string }
+  ultraplanLaunchPending?: { blurb: string; profile?: 'fast' | 'deep' | 'max' }
   // Remote-harness side: set via set_permission_mode control_request,
   // pushed to CCR external_metadata.is_ultraplan_mode by onChangeAppState.
   isUltraplanMode?: boolean

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -102,6 +102,12 @@ export function isAnthropicAuthEnabled(): boolean {
   // --bare: API-key-only, never OAuth.
   if (isBareMode()) return false
 
+  // OpenAI-compatible provider with an explicit API key should not trigger
+  // Anthropic login/onboarding flows.
+  if (getAPIProvider() === 'openai' && !!getCodexApiKey()) {
+    return false
+  }
+
   // `claude ssh` remote: ANTHROPIC_UNIX_SOCKET tunnels API calls through a
   // local auth-injecting proxy. The launcher sets CLAUDE_CODE_OAUTH_TOKEN as a
   // placeholder iff the local side is a subscriber (so the remote includes the
@@ -1366,6 +1372,18 @@ export function clearCodexOAuthTokens(): void {
   })
 }
 
+export function getCodexApiKey(): string | null {
+  return (
+    process.env.OPENAI_API_KEY ||
+    process.env.CLAUDE_CODE_OPENAI_API_KEY ||
+    null
+  )
+}
+
+export function getCodexAuthToken(): string | null {
+  return getCodexApiKey() || getCodexOAuthTokens()?.accessToken || null
+}
+
 
 let lastCredentialsMtimeMs = 0
 
@@ -1632,9 +1650,7 @@ export function isCodexSubscriber(): boolean {
     return false
   }
 
-  // Verify we actually have valid Codex tokens
-  const tokens = getCodexOAuthTokens()
-  return !!tokens?.accessToken
+  return !!getCodexAuthToken()
 }
 
 /**

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -368,11 +368,13 @@ export function renderModelSetting(setting: ModelName | ModelAlias): string {
  */
 export function getPublicModelDisplayName(model: ModelName): string | null {
   if (model.includes('gpt-') || model.includes('codex')) {
+    if (model === 'gpt-5.3-codex') return 'Codex 5.3'
     if (model === 'gpt-5.2-codex') return 'Codex 5.2'
     if (model === 'gpt-5.1-codex') return 'Codex 5.1'
     if (model === 'gpt-5.1-codex-mini') return 'Codex 5.1 Mini'
     if (model === 'gpt-5.1-codex-max') return 'Codex 5.1 Max'
     if (model === 'gpt-5.4') return 'GPT 5.4'
+    if (model === 'gpt-5.4-mini') return 'GPT 5.4 Mini'
     if (model === 'gpt-5.2') return 'GPT 5.2'
     return model
   }

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -25,6 +25,7 @@ import {
   getDefaultHaikuModel,
   getDefaultMainLoopModelSetting,
   getMarketingNameForModel,
+  modelDisplayString,
   getUserSpecifiedModelSetting,
   isOpus1mMergeEnabled,
   getOpus46PricingSuffix,
@@ -210,6 +211,15 @@ function getHaikuOption(): ModelOption {
 }
 
 // OpenAI Codex model options
+function getGpt52Option(): ModelOption {
+  return {
+    value: 'gpt-5.2',
+    label: 'GPT-5.2',
+    description: 'GPT-5.2 - Balanced general-purpose GPT model',
+    descriptionForModel: 'GPT-5.2 - balanced general-purpose reasoning and coding',
+  }
+}
+
 function getGpt54Option(): ModelOption {
   return {
     value: 'gpt-5.4',
@@ -228,12 +238,48 @@ function getGpt53CodexOption(): ModelOption {
   }
 }
 
+function getGpt52CodexOption(): ModelOption {
+  return {
+    value: 'gpt-5.2-codex',
+    label: 'GPT-5.2 Codex',
+    description: 'GPT-5.2 Codex - Frontier agentic coding model',
+    descriptionForModel: 'GPT-5.2 Codex - frontier agentic coding model',
+  }
+}
+
+function getGpt51CodexOption(): ModelOption {
+  return {
+    value: 'gpt-5.1-codex',
+    label: 'GPT-5.1 Codex',
+    description: 'GPT-5.1 Codex - Codex coding model',
+    descriptionForModel: 'GPT-5.1 Codex - coding-focused Codex model',
+  }
+}
+
 function getGpt54MiniOption(): ModelOption {
   return {
     value: 'gpt-5.4-mini',
     label: 'GPT-5.4 Mini',
     description: 'GPT-5.4 Mini · Fast and efficient for simple tasks',
     descriptionForModel: 'GPT-5.4 Mini - fast and efficient for simple coding tasks',
+  }
+}
+
+function getGpt51CodexMiniOption(): ModelOption {
+  return {
+    value: 'gpt-5.1-codex-mini',
+    label: 'GPT-5.1 Codex Mini',
+    description: 'GPT-5.1 Codex Mini - Fast Codex model for lighter tasks',
+    descriptionForModel: 'GPT-5.1 Codex Mini - fast Codex model for lighter tasks',
+  }
+}
+
+function getGpt51CodexMaxOption(): ModelOption {
+  return {
+    value: 'gpt-5.1-codex-max',
+    label: 'GPT-5.1 Codex Max',
+    description: 'GPT-5.1 Codex Max - Highest-capability Codex model',
+    descriptionForModel: 'GPT-5.1 Codex Max - highest-capability Codex model',
   }
 }
 
@@ -321,8 +367,13 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     return [
       getDefaultOptionForUser(),
       getGpt54Option(),
+      getGpt52Option(),
       getGpt53CodexOption(),
+      getGpt52CodexOption(),
       getGpt54MiniOption(),
+      getGpt51CodexOption(),
+      getGpt51CodexMiniOption(),
+      getGpt51CodexMaxOption(),
     ]
   }
 
@@ -533,17 +584,19 @@ export function getModelOptions(fastMode = false): ModelOption[] {
     customModel = initialMainLoopModel
   }
   if (customModel === null || options.some(opt => opt.value === customModel)) {
-    return filterModelOptionsByAllowlist(options)
+    return filterModelOptionsByAllowlist(appendConfiguredAvailableModels(options))
   } else if (customModel === 'opusplan') {
-    return filterModelOptionsByAllowlist([...options, getOpusPlanOption()])
+    return filterModelOptionsByAllowlist(
+      appendConfiguredAvailableModels([...options, getOpusPlanOption()]),
+    )
   } else if (customModel === 'opus' && getAPIProvider() === 'firstParty') {
     return filterModelOptionsByAllowlist([
-      ...options,
+      ...appendConfiguredAvailableModels(options),
       getMaxOpusOption(fastMode),
     ])
   } else if (customModel === 'opus[1m]' && getAPIProvider() === 'firstParty') {
     return filterModelOptionsByAllowlist([
-      ...options,
+      ...appendConfiguredAvailableModels(options),
       getMergedOpus1MOption(fastMode),
     ])
   } else {
@@ -559,8 +612,29 @@ export function getModelOptions(fastMode = false): ModelOption[] {
         description: 'Custom model',
       })
     }
-    return filterModelOptionsByAllowlist(options)
+    return filterModelOptionsByAllowlist(appendConfiguredAvailableModels(options))
   }
+}
+
+function appendConfiguredAvailableModels(options: ModelOption[]): ModelOption[] {
+  const settings = getSettings_DEPRECATED() || {}
+  const configured = settings.availableModels
+  if (!configured || configured.length === 0) {
+    return options
+  }
+
+  const merged = [...options]
+  for (const model of configured) {
+    if (!model || merged.some(existing => existing.value === model)) {
+      continue
+    }
+    merged.push({
+      value: model,
+      label: modelDisplayString(model),
+      description: 'Configured model',
+    })
+  }
+  return merged
 }
 
 /**

--- a/src/utils/soruxWrapper.ts
+++ b/src/utils/soruxWrapper.ts
@@ -1,0 +1,49 @@
+export function renderSoruxWrapper(repoRoot: string): string {
+  return [
+    '@echo off',
+    'setlocal',
+    '',
+    `set "FREECODE_ROOT=${repoRoot}"`,
+    'if exist "%FREECODE_ROOT%\\cli.exe" (',
+    '  "%FREECODE_ROOT%\\cli.exe" %*',
+    '  exit /b %errorlevel%',
+    ') else if exist "%FREECODE_ROOT%\\cli-dev.exe" (',
+    '  "%FREECODE_ROOT%\\cli-dev.exe" %*',
+    '  exit /b %errorlevel%',
+    ') else (',
+    '  echo cli-dev.exe / cli.exe not found under %FREECODE_ROOT%',
+    '  exit /b 1',
+    ')',
+    '',
+  ].join('\r\n')
+}
+
+export function updateSoruxWrapperContent(
+  existing: string,
+  repoRoot: string,
+): string {
+  let updated = existing.replace(
+    /set "FREECODE_ROOT=.*?"/,
+    `set "FREECODE_ROOT=${repoRoot}"`,
+  )
+
+  updated = updated.replace(/\r?\ncd \/d "%FREECODE_ROOT%"\r?\n/i, '\r\n')
+  updated = updated.replace(
+    /if exist "\.\\cli\.exe" \(/i,
+    'if exist "%FREECODE_ROOT%\\cli.exe" (',
+  )
+  updated = updated.replace(
+    /"\.\\cli\.exe"/gi,
+    '"%FREECODE_ROOT%\\cli.exe"',
+  )
+  updated = updated.replace(
+    /else if exist "\.\\cli-dev\.exe" \(/i,
+    'else if exist "%FREECODE_ROOT%\\cli-dev.exe" (',
+  )
+  updated = updated.replace(
+    /"\.\\cli-dev\.exe"/gi,
+    '"%FREECODE_ROOT%\\cli-dev.exe"',
+  )
+
+  return updated
+}

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -12,6 +12,7 @@ import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js
 import { getAgentDescriptionsTotalTokens, AGENT_DESCRIPTIONS_THRESHOLD } from './statusNoticeHelpers.js';
 import { isSupportedJetBrainsTerminal, toIDEDisplayName, getTerminalIdeType } from './ide.js';
 import { isJetBrainsPluginInstalledCachedSync } from './jetbrains.js';
+import { getAPIProvider } from './model/providers.js';
 
 // Types
 export type StatusNoticeType = 'warning' | 'info';
@@ -99,6 +100,9 @@ const bothAuthMethodsNotice: StatusNoticeDefinition = {
   id: 'both-auth-methods',
   type: 'warning',
   isActive: () => {
+    if (getAPIProvider() !== 'firstParty') {
+      return false;
+    }
     const {
       source: apiKeySource
     } = getAnthropicApiKeyWithSource({

--- a/src/utils/ultraplan/artifactPreview.ts
+++ b/src/utils/ultraplan/artifactPreview.ts
@@ -86,3 +86,19 @@ export function formatUltraplanArtifactPreview(
   if (normalized.length <= maxChars) return normalized
   return `${normalized.slice(0, maxChars)}\n\n... (truncated)`
 }
+
+export function buildUltraplanArtifactMessage(
+  key: UltraplanArtifactKey,
+  runDir: string,
+  content: string | null,
+): string {
+  const descriptor = ARTIFACTS.find(item => item.key === key)
+  const title = descriptor?.label ?? key
+  const body = formatUltraplanArtifactPreview(key, content, 12000)
+  return [
+    `Ultraplan artifact: ${title}`,
+    `Run dir: ${runDir}`,
+    '',
+    body,
+  ].join('\n')
+}

--- a/src/utils/ultraplan/artifactPreview.ts
+++ b/src/utils/ultraplan/artifactPreview.ts
@@ -1,0 +1,88 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+export type UltraplanArtifactKey =
+  | 'plan'
+  | 'workspaceSnapshot'
+  | 'stdout'
+  | 'stderr'
+
+export type UltraplanArtifactDescriptor = {
+  key: UltraplanArtifactKey
+  label: string
+  filename: string
+  path: string
+}
+
+const ARTIFACTS: Array<{
+  key: UltraplanArtifactKey
+  label: string
+  filename: string
+}> = [
+  {
+    key: 'plan',
+    label: 'Plan',
+    filename: 'plan.md',
+  },
+  {
+    key: 'workspaceSnapshot',
+    label: 'Workspace snapshot',
+    filename: 'workspace-snapshot.md',
+  },
+  {
+    key: 'stdout',
+    label: 'Planner stdout',
+    filename: 'stdout.log',
+  },
+  {
+    key: 'stderr',
+    label: 'Planner stderr',
+    filename: 'stderr.log',
+  },
+]
+
+export function listUltraplanArtifacts(
+  runDir: string,
+): UltraplanArtifactDescriptor[] {
+  return ARTIFACTS.map(item => ({
+    ...item,
+    path: join(runDir, item.filename),
+  }))
+}
+
+export async function readUltraplanArtifact(
+  runDir: string,
+  key: UltraplanArtifactKey,
+): Promise<string | null> {
+  const artifact = listUltraplanArtifacts(runDir).find(item => item.key === key)
+  if (!artifact) return null
+  try {
+    return await readFile(artifact.path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+export function formatUltraplanArtifactPreview(
+  key: UltraplanArtifactKey,
+  content: string | null,
+  maxChars = 3200,
+): string {
+  if (!content || !content.trim()) {
+    switch (key) {
+      case 'stderr':
+        return 'No stderr output captured.'
+      case 'stdout':
+        return 'No stdout output captured.'
+      case 'workspaceSnapshot':
+        return 'No workspace snapshot artifact found.'
+      case 'plan':
+      default:
+        return 'No plan artifact found.'
+    }
+  }
+
+  const normalized = content.trim()
+  if (normalized.length <= maxChars) return normalized
+  return `${normalized.slice(0, maxChars)}\n\n... (truncated)`
+}

--- a/src/utils/ultraplan/artifacts.ts
+++ b/src/utils/ultraplan/artifacts.ts
@@ -40,6 +40,8 @@ export type UltraplanRunPaths = {
   requestPath: string
   statusPath: string
   summaryPath: string
+  workspaceSnapshotPath: string
+  workspaceSnapshotJsonPath: string
   planPath: string
   promptPath: string
   systemPromptPath: string
@@ -67,6 +69,8 @@ export async function createUltraplanRunPaths(): Promise<UltraplanRunPaths> {
     requestPath: join(dir, 'request.json'),
     statusPath: join(dir, 'status.json'),
     summaryPath: join(dir, 'summary.json'),
+    workspaceSnapshotPath: join(dir, 'workspace-snapshot.md'),
+    workspaceSnapshotJsonPath: join(dir, 'workspace-snapshot.json'),
     planPath: join(dir, 'plan.md'),
     promptPath: join(dir, 'prompt.txt'),
     systemPromptPath: join(dir, 'system-prompt.txt'),

--- a/src/utils/ultraplan/artifacts.ts
+++ b/src/utils/ultraplan/artifacts.ts
@@ -1,0 +1,138 @@
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { getClaudeConfigHomeDir } from '../envUtils.js'
+
+export type UltraplanRunStatus =
+  | 'pending'
+  | 'launching'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'stopped'
+
+export type UltraplanStatusFile = {
+  status: UltraplanRunStatus
+  updatedAt: number
+  message?: string
+}
+
+export type UltraplanSummaryFile = {
+  startedAt?: number
+  completedAt?: number
+  launcher?: string
+  commandPreview?: string
+  error?: string
+}
+
+export type UltraplanRequestFile = {
+  id: string
+  topic: string
+  cwd: string
+  createdAt: number
+  sourceSessionId?: string
+  seedPlan?: string
+}
+
+export type UltraplanRunPaths = {
+  id: string
+  dir: string
+  requestPath: string
+  statusPath: string
+  summaryPath: string
+  planPath: string
+  promptPath: string
+  systemPromptPath: string
+  scriptPath: string
+  stdoutPath: string
+  stderrPath: string
+}
+
+const STATUS_FALLBACK: UltraplanStatusFile = {
+  status: 'pending',
+  updatedAt: 0,
+}
+
+function getRunDir(id: string): string {
+  return join(getClaudeConfigHomeDir(), 'ultraplan', 'runs', id)
+}
+
+export async function createUltraplanRunPaths(): Promise<UltraplanRunPaths> {
+  const id = randomUUID()
+  const dir = getRunDir(id)
+  await mkdir(dir, { recursive: true })
+  return {
+    id,
+    dir,
+    requestPath: join(dir, 'request.json'),
+    statusPath: join(dir, 'status.json'),
+    summaryPath: join(dir, 'summary.json'),
+    planPath: join(dir, 'plan.md'),
+    promptPath: join(dir, 'prompt.txt'),
+    systemPromptPath: join(dir, 'system-prompt.txt'),
+    scriptPath: join(dir, process.platform === 'win32' ? 'run.ps1' : 'run.sh'),
+    stdoutPath: join(dir, 'stdout.log'),
+    stderrPath: join(dir, 'stderr.log'),
+  }
+}
+
+export async function writeUltraplanRequest(
+  paths: UltraplanRunPaths,
+  request: UltraplanRequestFile,
+): Promise<void> {
+  await writeJson(paths.requestPath, request)
+}
+
+export async function writeUltraplanStatus(
+  paths: UltraplanRunPaths,
+  status: UltraplanRunStatus,
+  message?: string,
+): Promise<void> {
+  await writeJson(paths.statusPath, {
+    status,
+    updatedAt: Date.now(),
+    ...(message ? { message } : {}),
+  } satisfies UltraplanStatusFile)
+}
+
+export async function writeUltraplanSummary(
+  paths: UltraplanRunPaths,
+  summary: UltraplanSummaryFile,
+): Promise<void> {
+  await writeJson(paths.summaryPath, summary)
+}
+
+export async function readUltraplanStatus(
+  paths: Pick<UltraplanRunPaths, 'statusPath'>,
+): Promise<UltraplanStatusFile> {
+  return (await readJson(paths.statusPath)) ?? STATUS_FALLBACK
+}
+
+export async function readUltraplanSummary(
+  paths: Pick<UltraplanRunPaths, 'summaryPath'>,
+): Promise<UltraplanSummaryFile> {
+  return (await readJson(paths.summaryPath)) ?? {}
+}
+
+export async function readUltraplanPlan(
+  paths: Pick<UltraplanRunPaths, 'planPath'>,
+): Promise<string | null> {
+  try {
+    return await readFile(paths.planPath, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, JSON.stringify(value, null, 2), 'utf8')
+}
+
+async function readJson<T>(path: string): Promise<T | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}

--- a/src/utils/ultraplan/artifacts.ts
+++ b/src/utils/ultraplan/artifacts.ts
@@ -30,6 +30,7 @@ export type UltraplanRequestFile = {
   topic: string
   cwd: string
   createdAt: number
+  profile?: 'fast' | 'deep' | 'max'
   sourceSessionId?: string
   seedPlan?: string
 }

--- a/src/utils/ultraplan/localSession.ts
+++ b/src/utils/ultraplan/localSession.ts
@@ -1,0 +1,304 @@
+import { writeFile } from 'fs/promises'
+import {
+  createTaskStateBase,
+  generateTaskId,
+  type SetAppState,
+} from '../../Task.js'
+import { getSessionId } from '../../bootstrap/state.js'
+import type { AppState } from '../../state/AppStateStore.js'
+import type { LocalWorkflowTaskState } from '../../tasks/LocalWorkflowTask/LocalWorkflowTask.js'
+import { enqueuePendingNotification } from '../messageQueueManager.js'
+import { registerTask, updateTaskState } from '../task/framework.js'
+import {
+  createUltraplanRunPaths,
+  readUltraplanPlan,
+  readUltraplanStatus,
+  readUltraplanSummary,
+  writeUltraplanRequest,
+  writeUltraplanStatus,
+  writeUltraplanSummary,
+  type UltraplanRunPaths,
+} from './artifacts.js'
+import {
+  buildUltraplanSystemPrompt,
+  buildUltraplanUserPrompt,
+} from './plannerPrompt.js'
+import { launchUltraplanTerminal } from './terminalLauncher.js'
+
+const POLL_MS = 1200
+
+export async function startLocalUltraplan(opts: {
+  topic: string
+  seedPlan?: string
+  getAppState: () => AppState
+  setAppState: SetAppState
+  onSessionReady?: (message: string) => void
+}): Promise<string> {
+  const { topic, seedPlan, getAppState, setAppState, onSessionReady } = opts
+  const paths = await createUltraplanRunPaths()
+  const taskId = createUltraplanTask(setAppState, topic, paths.dir)
+
+  await writeUltraplanRequest(paths, {
+    id: paths.id,
+    topic,
+    cwd: process.cwd(),
+    createdAt: Date.now(),
+    sourceSessionId: getSessionId(),
+    ...(seedPlan ? { seedPlan } : {}),
+  })
+  await writeUltraplanStatus(paths, 'launching', 'Preparing local planner')
+  await writeFile(paths.systemPromptPath, buildUltraplanSystemPrompt(), 'utf8')
+  await writeFile(
+    paths.promptPath,
+    buildUltraplanUserPrompt(topic, seedPlan),
+    'utf8',
+  )
+  await writePlannerScript(paths)
+
+  const launched = await launchUltraplanTerminal(paths.scriptPath)
+  await writeUltraplanSummary(paths, {
+    startedAt: Date.now(),
+    launcher: launched.launcher,
+    commandPreview: launched.commandPreview,
+    ...(launched.error ? { error: launched.error } : {}),
+  })
+
+  if (!launched.ok) {
+    await writeUltraplanStatus(paths, 'failed', launched.error)
+    markUltraplanTask(taskId, setAppState, 'failed', launched.error)
+    return `ultraplan: failed to open a local terminal.\nRun dir: ${paths.dir}\nReason: ${launched.error}`
+  }
+
+  setAppState(prev => ({
+    ...prev,
+    ultraplanSessionUrl: `local:${paths.dir}`,
+    ultraplanLaunching: undefined,
+  }))
+  markUltraplanTask(taskId, setAppState, 'running', 'Planner terminal launched')
+  onSessionReady?.(
+    `Ultraplan started in a new local terminal.\nRun dir: ${paths.dir}`,
+  )
+  void pollLocalUltraplan(paths, taskId, getAppState, setAppState)
+  return 'ultraplan\nLaunching local planner in a new terminal...'
+}
+
+export async function stopLocalUltraplan(
+  taskId: string,
+  runDirOrLocalRef: string,
+  setAppState: SetAppState,
+): Promise<void> {
+  const runDir = runDirOrLocalRef.startsWith('local:')
+    ? runDirOrLocalRef.slice('local:'.length)
+    : runDirOrLocalRef
+  const paths = materializeRunPaths(runDir)
+  await writeUltraplanStatus(paths, 'stopped', 'Stopped from the main session')
+  markUltraplanTask(taskId, setAppState, 'killed', 'Stopped')
+  setAppState(prev => ({
+    ...prev,
+    ultraplanSessionUrl: undefined,
+    ultraplanPendingChoice: undefined,
+    ultraplanLaunching: undefined,
+  }))
+  enqueuePendingNotification({
+    value: `Ultraplan stopped.\nRun dir: ${runDir}`,
+    mode: 'task-notification',
+  })
+}
+
+function createUltraplanTask(
+  setAppState: SetAppState,
+  topic: string,
+  runDir: string,
+): string {
+  const taskId = generateTaskId('local_workflow')
+  const task: LocalWorkflowTaskState = {
+    ...createTaskStateBase(taskId, 'local_workflow', `Ultraplan: ${topic}`),
+    type: 'local_workflow',
+    status: 'running',
+    workflowName: 'ultraplan',
+    summary: `Planning in ${runDir}`,
+    agentCount: 1,
+    agents: [{ id: 'planner', name: 'planner', status: 'running' }],
+    isBackgrounded: true,
+  }
+  registerTask(task, setAppState)
+  return taskId
+}
+
+function markUltraplanTask(
+  taskId: string,
+  setAppState: SetAppState,
+  status: LocalWorkflowTaskState['status'],
+  summary?: string,
+): void {
+  updateTaskState<LocalWorkflowTaskState>(taskId, setAppState, task => ({
+    ...task,
+    status,
+    summary: summary ?? task.summary,
+    endTime:
+      status === 'running' || status === 'pending' ? task.endTime : Date.now(),
+    agents: (task.agents ?? []).map(agent => ({
+      ...agent,
+      status:
+        status === 'completed'
+          ? 'completed'
+          : status === 'failed'
+            ? 'failed'
+            : status === 'killed'
+              ? 'skipped'
+              : 'running',
+    })),
+  }))
+}
+
+async function pollLocalUltraplan(
+  paths: UltraplanRunPaths,
+  taskId: string,
+  getAppState: () => AppState,
+  setAppState: SetAppState,
+): Promise<void> {
+  for (;;) {
+    await new Promise(resolve => setTimeout(resolve, POLL_MS))
+    if (getAppState().ultraplanSessionUrl !== `local:${paths.dir}`) return
+
+    const status = await readUltraplanStatus(paths)
+    if (status.status === 'launching' || status.status === 'pending') {
+      continue
+    }
+    if (status.status === 'running') {
+      markUltraplanTask(taskId, setAppState, 'running', status.message)
+      continue
+    }
+
+    if (status.status === 'completed') {
+      const plan = (await readUltraplanPlan(paths))?.trim()
+      if (!plan) {
+        const summary = await readUltraplanSummary(paths)
+        await writeUltraplanStatus(
+          paths,
+          'failed',
+          summary.error ?? 'Planner exited without producing a plan',
+        )
+        markUltraplanTask(taskId, setAppState, 'failed', summary.error)
+        enqueuePendingNotification({
+          value: `Ultraplan failed: no plan.md was produced.\nRun dir: ${paths.dir}`,
+          mode: 'task-notification',
+        })
+        setAppState(prev => ({
+          ...prev,
+          ultraplanSessionUrl: undefined,
+        }))
+        return
+      }
+
+      markUltraplanTask(taskId, setAppState, 'running', 'Plan ready for review')
+      setAppState(prev => ({
+        ...prev,
+        ultraplanPendingChoice: {
+          plan,
+          sessionId: paths.dir,
+          taskId,
+        },
+      }))
+      enqueuePendingNotification({
+        value: `Ultraplan plan is ready.\nRun dir: ${paths.dir}`,
+        mode: 'task-notification',
+      })
+      return
+    }
+
+    const summary = await readUltraplanSummary(paths)
+    markUltraplanTask(
+      taskId,
+      setAppState,
+      status.status === 'stopped' ? 'killed' : 'failed',
+      summary.error ?? status.message,
+    )
+    setAppState(prev => ({
+      ...prev,
+      ultraplanSessionUrl: undefined,
+    }))
+    enqueuePendingNotification({
+      value: `Ultraplan ${status.status}: ${summary.error ?? status.message ?? 'unknown error'}\nRun dir: ${paths.dir}`,
+      mode: 'task-notification',
+    })
+    return
+  }
+}
+
+async function writePlannerScript(paths: UltraplanRunPaths): Promise<void> {
+  if (process.platform !== 'win32') {
+    await writeFile(
+      paths.scriptPath,
+      '#!/usr/bin/env bash\necho "Local ultraplan terminal launch currently supports Windows first."\n',
+      'utf8',
+    )
+    return
+  }
+
+  const q = (value: string) => `'${value.replace(/'/g, "''")}'`
+  const cliPath = process.execPath
+  const model = process.env.ANTHROPIC_MODEL || ''
+  const script = [
+    '$ErrorActionPreference = "Stop"',
+    `$runDir = ${q(paths.dir)}`,
+    `$statusPath = ${q(paths.statusPath)}`,
+    `$summaryPath = ${q(paths.summaryPath)}`,
+    `$promptPath = ${q(paths.promptPath)}`,
+    `$systemPromptPath = ${q(paths.systemPromptPath)}`,
+    `$planPath = ${q(paths.planPath)}`,
+    `$stdoutPath = ${q(paths.stdoutPath)}`,
+    `$stderrPath = ${q(paths.stderrPath)}`,
+    `$cliPath = ${q(cliPath)}`,
+    `$cwd = ${q(process.cwd())}`,
+    '$prompt = Get-Content -LiteralPath $promptPath -Raw',
+    'Set-Location -LiteralPath $cwd',
+    `@{ status = 'running'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = 'Planner is reading the repo' } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
+    'try {',
+    '  $arguments = @(',
+    "    '-p',",
+    "    '--bare',",
+    "    '--output-format','text',",
+    "    '--allowedTools','Read,Glob,Grep',",
+    "    '--append-system-prompt-file',$systemPromptPath,",
+    "    '--max-turns','8'",
+    '  )',
+    ...(model ? [`  $arguments += @('--model', ${q(model)})`] : []),
+    '  $arguments += $prompt',
+    '  & $cliPath @arguments 2> $stderrPath | Tee-Object -FilePath $planPath | Tee-Object -FilePath $stdoutPath',
+    '  $exitCode = $LASTEXITCODE',
+    '  if ($exitCode -ne 0) { throw "planner exited with code $exitCode" }',
+    '  if (-not (Test-Path -LiteralPath $planPath)) { throw "planner did not create plan.md" }',
+    '  $plan = (Get-Content -LiteralPath $planPath -Raw).Trim()',
+    '  if ([string]::IsNullOrWhiteSpace($plan)) { throw "planner returned empty output" }',
+    `  @{ status = 'completed'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = 'Plan completed' } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
+    `  @{ completedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); launcher = 'powershell'; commandPreview = 'cli --print ultraplan' } | ConvertTo-Json | Set-Content -LiteralPath $summaryPath -Encoding utf8`,
+    '} catch {',
+    '  $message = $_.Exception.Message',
+    `  @{ status = 'failed'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = $message } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
+    `  @{ completedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); launcher = 'powershell'; error = $message } | ConvertTo-Json | Set-Content -LiteralPath $summaryPath -Encoding utf8`,
+    '  Write-Host ""',
+    '  Write-Host "Ultraplan failed: $message" -ForegroundColor Red',
+    '}',
+    'Write-Host ""',
+    'Write-Host "Ultraplan artifacts: $runDir" -ForegroundColor Cyan',
+  ].join('\n')
+
+  await writeFile(paths.scriptPath, script, 'utf8')
+}
+
+function materializeRunPaths(dir: string): UltraplanRunPaths {
+  return {
+    id: dir.split(/[\\/]/).at(-1) ?? 'unknown',
+    dir,
+    requestPath: `${dir}/request.json`,
+    statusPath: `${dir}/status.json`,
+    summaryPath: `${dir}/summary.json`,
+    planPath: `${dir}/plan.md`,
+    promptPath: `${dir}/prompt.txt`,
+    systemPromptPath: `${dir}/system-prompt.txt`,
+    scriptPath: `${dir}/${process.platform === 'win32' ? 'run.ps1' : 'run.sh'}`,
+    stdoutPath: `${dir}/stdout.log`,
+    stderrPath: `${dir}/stderr.log`,
+  }
+}

--- a/src/utils/ultraplan/localSession.ts
+++ b/src/utils/ultraplan/localSession.ts
@@ -23,6 +23,10 @@ import {
   buildUltraplanSystemPrompt,
   buildUltraplanUserPrompt,
 } from './plannerPrompt.js'
+import {
+  getUltraplanProfileConfig,
+  type UltraplanProfile,
+} from './profile.js'
 import { launchUltraplanTerminal } from './terminalLauncher.js'
 import {
   buildWorkspaceSnapshotMarkdown,
@@ -33,20 +37,30 @@ const POLL_MS = 1200
 
 export async function startLocalUltraplan(opts: {
   topic: string
+  profile?: UltraplanProfile
   seedPlan?: string
   getAppState: () => AppState
   setAppState: SetAppState
   onSessionReady?: (message: string) => void
 }): Promise<string> {
-  const { topic, seedPlan, getAppState, setAppState, onSessionReady } = opts
+  const {
+    topic,
+    profile = 'deep',
+    seedPlan,
+    getAppState,
+    setAppState,
+    onSessionReady,
+  } = opts
   const paths = await createUltraplanRunPaths()
   const taskId = createUltraplanTask(setAppState, topic, paths.dir)
+  const profileConfig = getUltraplanProfileConfig(profile)
 
   await writeUltraplanRequest(paths, {
     id: paths.id,
     topic,
     cwd: process.cwd(),
     createdAt: Date.now(),
+    profile,
     sourceSessionId: getSessionId(),
     ...(seedPlan ? { seedPlan } : {}),
   })
@@ -64,13 +78,17 @@ export async function startLocalUltraplan(opts: {
     workspaceSnapshotMarkdown,
     'utf8',
   )
-  await writeFile(paths.systemPromptPath, buildUltraplanSystemPrompt(), 'utf8')
   await writeFile(
-    paths.promptPath,
-    buildUltraplanUserPrompt(topic, workspaceSnapshotMarkdown, seedPlan),
+    paths.systemPromptPath,
+    buildUltraplanSystemPrompt(profile),
     'utf8',
   )
-  await writePlannerScript(paths)
+  await writeFile(
+    paths.promptPath,
+    buildUltraplanUserPrompt(topic, workspaceSnapshotMarkdown, profile, seedPlan),
+    'utf8',
+  )
+  await writePlannerScript(paths, profile)
 
   const launched = await launchUltraplanTerminal(paths.scriptPath)
   await writeUltraplanSummary(paths, {
@@ -93,10 +111,10 @@ export async function startLocalUltraplan(opts: {
   }))
   markUltraplanTask(taskId, setAppState, 'running', 'Planner terminal launched')
   onSessionReady?.(
-    `Ultraplan started in a new local terminal.\nRun dir: ${paths.dir}`,
+    `Ultraplan (${profileConfig.name}) started in a new local terminal.\nRun dir: ${paths.dir}`,
   )
   void pollLocalUltraplan(paths, taskId, getAppState, setAppState)
-  return 'ultraplan\nLaunching local planner in a new terminal...'
+  return `ultraplan\nLaunching ${profileConfig.name} local planner in a new terminal...`
 }
 
 export async function stopLocalUltraplan(
@@ -243,7 +261,10 @@ async function pollLocalUltraplan(
   }
 }
 
-async function writePlannerScript(paths: UltraplanRunPaths): Promise<void> {
+async function writePlannerScript(
+  paths: UltraplanRunPaths,
+  profile: UltraplanProfile,
+): Promise<void> {
   if (process.platform !== 'win32') {
     await writeFile(
       paths.scriptPath,
@@ -256,6 +277,7 @@ async function writePlannerScript(paths: UltraplanRunPaths): Promise<void> {
   const q = (value: string) => `'${value.replace(/'/g, "''")}'`
   const cliPath = process.execPath
   const model = process.env.ANTHROPIC_MODEL || ''
+  const profileConfig = getUltraplanProfileConfig(profile)
   const script = [
     '$ErrorActionPreference = "Stop"',
     `$runDir = ${q(paths.dir)}`,
@@ -270,7 +292,7 @@ async function writePlannerScript(paths: UltraplanRunPaths): Promise<void> {
     `$cwd = ${q(process.cwd())}`,
     '$prompt = Get-Content -LiteralPath $promptPath -Raw',
     'Set-Location -LiteralPath $cwd',
-    `@{ status = 'running'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = 'Planner is reading the repo' } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
+    `@{ status = 'running'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = 'Planner is reading the repo (${profileConfig.name})' } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
     'try {',
     '  $arguments = @(',
     "    '-p',",
@@ -278,7 +300,7 @@ async function writePlannerScript(paths: UltraplanRunPaths): Promise<void> {
     "    '--output-format','text',",
     "    '--allowedTools','Read,Glob,Grep',",
     "    '--append-system-prompt-file',$systemPromptPath,",
-    "    '--max-turns','8'",
+    `    '--max-turns','${profileConfig.maxTurns}'`,
     '  )',
     ...(model ? [`  $arguments += @('--model', ${q(model)})`] : []),
     '  $arguments += $prompt',
@@ -288,8 +310,8 @@ async function writePlannerScript(paths: UltraplanRunPaths): Promise<void> {
     '  if (-not (Test-Path -LiteralPath $planPath)) { throw "planner did not create plan.md" }',
     '  $plan = (Get-Content -LiteralPath $planPath -Raw).Trim()',
     '  if ([string]::IsNullOrWhiteSpace($plan)) { throw "planner returned empty output" }',
-    `  @{ status = 'completed'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = 'Plan completed' } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
-    `  @{ completedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); launcher = 'powershell'; commandPreview = 'cli --print ultraplan' } | ConvertTo-Json | Set-Content -LiteralPath $summaryPath -Encoding utf8`,
+    `  @{ status = 'completed'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = 'Plan completed (${profileConfig.name})' } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,
+    `  @{ completedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); launcher = 'powershell'; commandPreview = 'cli --print ultraplan --${profileConfig.name}' } | ConvertTo-Json | Set-Content -LiteralPath $summaryPath -Encoding utf8`,
     '} catch {',
     '  $message = $_.Exception.Message',
     `  @{ status = 'failed'; updatedAt = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(); message = $message } | ConvertTo-Json | Set-Content -LiteralPath $statusPath -Encoding utf8`,

--- a/src/utils/ultraplan/localSession.ts
+++ b/src/utils/ultraplan/localSession.ts
@@ -24,6 +24,10 @@ import {
   buildUltraplanUserPrompt,
 } from './plannerPrompt.js'
 import { launchUltraplanTerminal } from './terminalLauncher.js'
+import {
+  buildWorkspaceSnapshotMarkdown,
+  collectWorkspaceSnapshot,
+} from './workspaceSnapshot.js'
 
 const POLL_MS = 1200
 
@@ -47,10 +51,23 @@ export async function startLocalUltraplan(opts: {
     ...(seedPlan ? { seedPlan } : {}),
   })
   await writeUltraplanStatus(paths, 'launching', 'Preparing local planner')
+  const workspaceSnapshot = await collectWorkspaceSnapshot(process.cwd())
+  const workspaceSnapshotMarkdown =
+    buildWorkspaceSnapshotMarkdown(workspaceSnapshot)
+  await writeFile(
+    paths.workspaceSnapshotJsonPath,
+    JSON.stringify(workspaceSnapshot, null, 2),
+    'utf8',
+  )
+  await writeFile(
+    paths.workspaceSnapshotPath,
+    workspaceSnapshotMarkdown,
+    'utf8',
+  )
   await writeFile(paths.systemPromptPath, buildUltraplanSystemPrompt(), 'utf8')
   await writeFile(
     paths.promptPath,
-    buildUltraplanUserPrompt(topic, seedPlan),
+    buildUltraplanUserPrompt(topic, workspaceSnapshotMarkdown, seedPlan),
     'utf8',
   )
   await writePlannerScript(paths)
@@ -294,6 +311,8 @@ function materializeRunPaths(dir: string): UltraplanRunPaths {
     requestPath: `${dir}/request.json`,
     statusPath: `${dir}/status.json`,
     summaryPath: `${dir}/summary.json`,
+    workspaceSnapshotPath: `${dir}/workspace-snapshot.md`,
+    workspaceSnapshotJsonPath: `${dir}/workspace-snapshot.json`,
     planPath: `${dir}/plan.md`,
     promptPath: `${dir}/prompt.txt`,
     systemPromptPath: `${dir}/system-prompt.txt`,

--- a/src/utils/ultraplan/localSession.ts
+++ b/src/utils/ultraplan/localSession.ts
@@ -80,7 +80,7 @@ export async function startLocalUltraplan(opts: {
   )
   await writeFile(
     paths.systemPromptPath,
-    buildUltraplanSystemPrompt(profile),
+    buildUltraplanSystemPrompt(profile, Boolean(seedPlan?.trim())),
     'utf8',
   )
   await writeFile(

--- a/src/utils/ultraplan/plannerPrompt.ts
+++ b/src/utils/ultraplan/plannerPrompt.ts
@@ -2,6 +2,7 @@ export function buildUltraplanSystemPrompt(): string {
   return [
     'You are running a local ultraplan session inside freecode.',
     'Your job is to produce a deep implementation plan only.',
+    'You will receive a generated workspace snapshot. Treat it as a fast local map, then validate important details with read-only repo inspection.',
     '',
     'Hard constraints:',
     '- Do not modify files.',
@@ -23,10 +24,21 @@ export function buildUltraplanSystemPrompt(): string {
   ].join('\n')
 }
 
-export function buildUltraplanUserPrompt(topic: string, seedPlan?: string): string {
-  const parts = [
-    `Create a deep local implementation plan for this task:\n\n${topic}`,
-  ]
+export function buildUltraplanUserPrompt(
+  topic: string,
+  workspaceSnapshot: string,
+  seedPlan?: string,
+): string {
+  const parts = [`Create a deep local implementation plan for this task:\n\n${topic}`]
+  parts.push(
+    [
+      'Generated workspace snapshot:',
+      '',
+      workspaceSnapshot,
+      '',
+      'Use this snapshot to accelerate planning, but verify code-level assumptions with Read/Glob/Grep before making claims.',
+    ].join('\n'),
+  )
   if (seedPlan?.trim()) {
     parts.push(`Existing draft plan to refine:\n\n${seedPlan.trim()}`)
   }

--- a/src/utils/ultraplan/plannerPrompt.ts
+++ b/src/utils/ultraplan/plannerPrompt.ts
@@ -1,8 +1,18 @@
-export function buildUltraplanSystemPrompt(): string {
+import {
+  getUltraplanProfileConfig,
+  type UltraplanProfile,
+} from './profile.js'
+
+export function buildUltraplanSystemPrompt(
+  profile: UltraplanProfile = 'deep',
+): string {
+  const config = getUltraplanProfileConfig(profile)
   return [
     'You are running a local ultraplan session inside freecode.',
     'Your job is to produce a deep implementation plan only.',
     'You will receive a generated workspace snapshot. Treat it as a fast local map, then validate important details with read-only repo inspection.',
+    `Selected planning profile: ${config.label} (${config.name}).`,
+    config.planningDirective,
     '',
     'Hard constraints:',
     '- Do not modify files.',
@@ -27,9 +37,14 @@ export function buildUltraplanSystemPrompt(): string {
 export function buildUltraplanUserPrompt(
   topic: string,
   workspaceSnapshot: string,
+  profile: UltraplanProfile = 'deep',
   seedPlan?: string,
 ): string {
+  const config = getUltraplanProfileConfig(profile)
   const parts = [`Create a deep local implementation plan for this task:\n\n${topic}`]
+  parts.push(
+    `Use the ${config.label} planning profile. ${config.planningDirective}`,
+  )
   parts.push(
     [
       'Generated workspace snapshot:',

--- a/src/utils/ultraplan/plannerPrompt.ts
+++ b/src/utils/ultraplan/plannerPrompt.ts
@@ -1,0 +1,34 @@
+export function buildUltraplanSystemPrompt(): string {
+  return [
+    'You are running a local ultraplan session inside freecode.',
+    'Your job is to produce a deep implementation plan only.',
+    '',
+    'Hard constraints:',
+    '- Do not modify files.',
+    '- Do not run write-capable or destructive commands.',
+    '- Do not use Edit, Write, NotebookEdit, or any tool that changes the repo.',
+    '- Prefer Read, Glob, and Grep for codebase inspection.',
+    '- If information is missing, state assumptions explicitly.',
+    '',
+    'Output format:',
+    'Return only Markdown with these sections in order:',
+    '1. Goal',
+    '2. Constraints',
+    '3. Current Codebase Findings',
+    '4. Architecture',
+    '5. Workstreams',
+    '6. Risks',
+    '7. Validation',
+    '8. Step-by-step Execution Plan',
+  ].join('\n')
+}
+
+export function buildUltraplanUserPrompt(topic: string, seedPlan?: string): string {
+  const parts = [
+    `Create a deep local implementation plan for this task:\n\n${topic}`,
+  ]
+  if (seedPlan?.trim()) {
+    parts.push(`Existing draft plan to refine:\n\n${seedPlan.trim()}`)
+  }
+  return parts.join('\n\n')
+}

--- a/src/utils/ultraplan/plannerPrompt.ts
+++ b/src/utils/ultraplan/plannerPrompt.ts
@@ -5,8 +5,30 @@ import {
 
 export function buildUltraplanSystemPrompt(
   profile: UltraplanProfile = 'deep',
+  hasSeedPlan = false,
 ): string {
   const config = getUltraplanProfileConfig(profile)
+  const outputSections = hasSeedPlan
+    ? [
+        '1. Goal',
+        '2. Existing Plan Assessment',
+        '3. Keep',
+        '4. Change',
+        '5. Add',
+        '6. Revised Execution Plan',
+        '7. Risks',
+        '8. Validation',
+      ]
+    : [
+        '1. Goal',
+        '2. Constraints',
+        '3. Current Codebase Findings',
+        '4. Architecture',
+        '5. Workstreams',
+        '6. Risks',
+        '7. Validation',
+        '8. Step-by-step Execution Plan',
+      ]
   return [
     'You are running a local ultraplan session inside freecode.',
     'Your job is to produce a deep implementation plan only.',
@@ -23,14 +45,7 @@ export function buildUltraplanSystemPrompt(
     '',
     'Output format:',
     'Return only Markdown with these sections in order:',
-    '1. Goal',
-    '2. Constraints',
-    '3. Current Codebase Findings',
-    '4. Architecture',
-    '5. Workstreams',
-    '6. Risks',
-    '7. Validation',
-    '8. Step-by-step Execution Plan',
+    ...outputSections,
   ].join('\n')
 }
 
@@ -55,6 +70,12 @@ export function buildUltraplanUserPrompt(
     ].join('\n'),
   )
   if (seedPlan?.trim()) {
+    parts.push(
+      [
+        'Start by critiquing the draft plan against the current codebase and task.',
+        'Then produce a structured refinement using Keep / Change / Add before writing the revised execution plan.',
+      ].join(' '),
+    )
     parts.push(`Existing draft plan to refine:\n\n${seedPlan.trim()}`)
   }
   return parts.join('\n\n')

--- a/src/utils/ultraplan/profile.ts
+++ b/src/utils/ultraplan/profile.ts
@@ -1,0 +1,105 @@
+export type UltraplanProfile = 'fast' | 'deep' | 'max'
+
+export type UltraplanProfileConfig = {
+  name: UltraplanProfile
+  label: string
+  maxTurns: number
+  planningDirective: string
+}
+
+const PROFILE_CONFIG: Record<UltraplanProfile, UltraplanProfileConfig> = {
+  fast: {
+    name: 'fast',
+    label: 'Fast',
+    maxTurns: 4,
+    planningDirective:
+      'Bias for speed. Collapse low-value branches, make explicit assumptions, and return the most actionable plan quickly.',
+  },
+  deep: {
+    name: 'deep',
+    label: 'Deep',
+    maxTurns: 8,
+    planningDirective:
+      'Balance thoroughness and speed. Inspect enough code to ground architecture, then produce a detailed but practical execution plan.',
+  },
+  max: {
+    name: 'max',
+    label: 'Max',
+    maxTurns: 14,
+    planningDirective:
+      'Go broad and deep. Surface architecture seams, migration concerns, validation matrix, rollback risk, and ordering dependencies before finalizing the plan.',
+  },
+}
+
+export function getUltraplanProfileConfig(
+  profile: UltraplanProfile,
+): UltraplanProfileConfig {
+  return PROFILE_CONFIG[profile]
+}
+
+export function parseUltraplanArgs(input: string): {
+  blurb: string
+  profile: UltraplanProfile
+} {
+  const tokens = input.trim().split(/\s+/).filter(Boolean)
+  if (!tokens.length) {
+    return { blurb: '', profile: 'deep' }
+  }
+
+  let profile: UltraplanProfile = 'deep'
+  const remaining: string[] = []
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]
+    const direct = parseProfileToken(token)
+    if (direct) {
+      profile = direct
+      continue
+    }
+    if (token === '--profile' || token === '--depth') {
+      const next = tokens[i + 1]
+      const parsed = next ? parseProfileName(next) : undefined
+      if (parsed) {
+        profile = parsed
+        i += 1
+        continue
+      }
+    }
+    remaining.push(token)
+  }
+
+  return {
+    blurb: remaining.join(' ').trim(),
+    profile,
+  }
+}
+
+function parseProfileToken(token: string): UltraplanProfile | undefined {
+  switch (token) {
+    case '--fast':
+      return 'fast'
+    case '--deep':
+      return 'deep'
+    case '--max':
+      return 'max'
+    default:
+      if (token.startsWith('--profile=')) {
+        return parseProfileName(token.slice('--profile='.length))
+      }
+      if (token.startsWith('--depth=')) {
+        return parseProfileName(token.slice('--depth='.length))
+      }
+      return undefined
+  }
+}
+
+function parseProfileName(value: string): UltraplanProfile | undefined {
+  switch (value.toLowerCase()) {
+    case 'fast':
+    case 'deep':
+    case 'max':
+      return value.toLowerCase() as UltraplanProfile
+    default:
+      return undefined
+  }
+}

--- a/src/utils/ultraplan/terminalLauncher.ts
+++ b/src/utils/ultraplan/terminalLauncher.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'child_process'
+
+export type LocalTerminalLaunchResult = {
+  ok: boolean
+  launcher: string
+  commandPreview: string
+  error?: string
+}
+
+function psSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+export async function launchUltraplanTerminal(
+  scriptPath: string,
+): Promise<LocalTerminalLaunchResult> {
+  if (process.platform !== 'win32') {
+    return {
+      ok: false,
+      launcher: 'unsupported',
+      commandPreview: scriptPath,
+      error: 'Local ultraplan terminal launch currently supports Windows first.',
+    }
+  }
+
+  const commandPreview = `powershell.exe -NoExit -ExecutionPolicy Bypass -File "${scriptPath}"`
+  const startCommand = [
+    'Start-Process',
+    'powershell.exe',
+    '-WindowStyle',
+    'Normal',
+    '-ArgumentList',
+    `@('-NoExit','-ExecutionPolicy','Bypass','-File',${psSingleQuote(scriptPath)})`,
+  ].join(' ')
+
+  try {
+    const child = spawn(
+      'powershell.exe',
+      ['-NoProfile', '-Command', startCommand],
+      {
+        detached: true,
+        stdio: 'ignore',
+      },
+    )
+    child.unref()
+    return {
+      ok: true,
+      launcher: 'powershell',
+      commandPreview,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      launcher: 'powershell',
+      commandPreview,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/utils/ultraplan/workspaceSnapshot.ts
+++ b/src/utils/ultraplan/workspaceSnapshot.ts
@@ -1,0 +1,319 @@
+import { readdir, readFile } from 'fs/promises'
+import { basename, join, relative } from 'path'
+
+import { execFileNoThrowWithCwd } from '../execFileNoThrow.js'
+
+const TOP_LEVEL_LIMIT = 24
+const GIT_STATUS_LIMIT = 20
+const GIT_COMMITS_LIMIT = 5
+const PLANNING_ARTIFACT_LIMIT = 12
+const MAX_ARTIFACT_DEPTH = 3
+
+const MANIFEST_FILES = [
+  'package.json',
+  'bunfig.toml',
+  'tsconfig.json',
+  'README.md',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'FEATURES.md',
+] as const
+
+const PLANNING_FILE_NAMES = new Set([
+  'IMPLEMENTATION_PLAN.md',
+  'PLAN.md',
+  'TODO.md',
+  'TASKS.md',
+  'SPEC.md',
+  'PRD.md',
+  'FEATURES.md',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'README.md',
+])
+
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.turbo',
+  '.bun-build',
+  '.tmp-anima',
+  '.tmp-save-buddy',
+])
+
+export type WorkspaceSnapshotManifest = {
+  path: string
+  summary: string
+}
+
+export type WorkspaceSnapshotGit = {
+  isRepo: boolean
+  branch?: string
+  head?: string
+  changedFiles: string[]
+  recentCommits: string[]
+}
+
+export type WorkspaceSnapshot = {
+  cwd: string
+  generatedAt: number
+  topLevel: {
+    directories: string[]
+    files: string[]
+  }
+  manifests: WorkspaceSnapshotManifest[]
+  planningArtifacts: string[]
+  git?: WorkspaceSnapshotGit
+}
+
+export async function collectWorkspaceSnapshot(
+  cwd: string,
+): Promise<WorkspaceSnapshot> {
+  const topLevel = await collectTopLevelEntries(cwd)
+  const manifests = await collectManifestSummaries(cwd)
+  const planningArtifacts = await collectPlanningArtifacts(cwd)
+  const git = await collectGitSnapshot(cwd)
+
+  return {
+    cwd,
+    generatedAt: Date.now(),
+    topLevel,
+    manifests,
+    planningArtifacts,
+    ...(git ? { git } : {}),
+  }
+}
+
+export function buildWorkspaceSnapshotMarkdown(
+  snapshot: WorkspaceSnapshot,
+): string {
+  const lines = [
+    '# Local Workspace Snapshot',
+    '',
+    `- cwd: ${snapshot.cwd}`,
+    `- generated_at: ${new Date(snapshot.generatedAt).toISOString()}`,
+  ]
+
+  if (snapshot.git?.isRepo) {
+    lines.push(
+      `- git_branch: ${snapshot.git.branch || '(detached or unknown)'}`,
+      `- git_head: ${snapshot.git.head || '(unknown)'}`,
+      `- git_changed_files: ${snapshot.git.changedFiles.length}`,
+    )
+  } else {
+    lines.push('- git: not a repository (or git unavailable)')
+  }
+
+  lines.push(
+    '',
+    '## Top-level directories',
+    ...formatBulletList(snapshot.topLevel.directories),
+    '',
+    '## Top-level files',
+    ...formatBulletList(snapshot.topLevel.files),
+    '',
+    '## Key manifests',
+    ...formatBulletList(
+      snapshot.manifests.map(item => `${item.path} — ${item.summary}`),
+    ),
+    '',
+    '## Planning artifacts',
+    ...formatBulletList(snapshot.planningArtifacts),
+  )
+
+  if (snapshot.git?.isRepo) {
+    lines.push(
+      '',
+      '## Git status',
+      ...formatBulletList(snapshot.git.changedFiles),
+      '',
+      '## Recent commits',
+      ...formatBulletList(snapshot.git.recentCommits),
+    )
+  }
+
+  return lines.join('\n')
+}
+
+async function collectTopLevelEntries(cwd: string): Promise<{
+  directories: string[]
+  files: string[]
+}> {
+  try {
+    const entries = await readdir(cwd, { withFileTypes: true })
+    const directories = entries
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name)
+      .sort((a, b) => a.localeCompare(b))
+      .slice(0, TOP_LEVEL_LIMIT)
+    const files = entries
+      .filter(entry => entry.isFile())
+      .map(entry => entry.name)
+      .sort((a, b) => a.localeCompare(b))
+      .slice(0, TOP_LEVEL_LIMIT)
+    return { directories, files }
+  } catch {
+    return { directories: [], files: [] }
+  }
+}
+
+async function collectManifestSummaries(
+  cwd: string,
+): Promise<WorkspaceSnapshotManifest[]> {
+  const results: WorkspaceSnapshotManifest[] = []
+  for (const file of MANIFEST_FILES) {
+    const fullPath = join(cwd, file)
+    const summary = await summarizeManifest(fullPath)
+    if (!summary) continue
+    results.push({ path: file, summary })
+  }
+  return results
+}
+
+async function summarizeManifest(path: string): Promise<string | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    const name = basename(path)
+    if (name === 'package.json') {
+      const parsed = JSON.parse(raw) as {
+        name?: string
+        packageManager?: string
+        scripts?: Record<string, string>
+      }
+      const scripts = Object.keys(parsed.scripts ?? {}).slice(0, 6)
+      return [
+        parsed.name ?? 'unnamed package',
+        parsed.packageManager ? `packageManager=${parsed.packageManager}` : null,
+        scripts.length ? `scripts=${scripts.join(', ')}` : 'scripts=none',
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    }
+    if (name === 'tsconfig.json') {
+      const parsed = JSON.parse(raw) as {
+        compilerOptions?: Record<string, unknown>
+      }
+      const compilerOptions = parsed.compilerOptions ?? {}
+      return [
+        compilerOptions.target ? `target=${compilerOptions.target}` : null,
+        compilerOptions.module ? `module=${compilerOptions.module}` : null,
+        compilerOptions.jsx ? `jsx=${compilerOptions.jsx}` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    }
+    if (name.endsWith('.md')) {
+      const heading = raw
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .find(line => line.startsWith('#'))
+      return heading ? heading.replace(/^#+\s*/, '') : 'Markdown guide present'
+    }
+    if (name === 'bunfig.toml') {
+      return 'Bun workspace config present'
+    }
+    return `${name} present`
+  } catch {
+    return null
+  }
+}
+
+async function collectPlanningArtifacts(cwd: string): Promise<string[]> {
+  const found = new Set<string>()
+  await walkForPlanningArtifacts(cwd, cwd, 0, found)
+  return Array.from(found).sort((a, b) => a.localeCompare(b))
+}
+
+async function walkForPlanningArtifacts(
+  root: string,
+  currentDir: string,
+  depth: number,
+  found: Set<string>,
+): Promise<void> {
+  if (depth > MAX_ARTIFACT_DEPTH || found.size >= PLANNING_ARTIFACT_LIMIT) return
+
+  let entries
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  for (const entry of entries) {
+    if (found.size >= PLANNING_ARTIFACT_LIMIT) return
+    const fullPath = join(currentDir, entry.name)
+    const relPath = relative(root, fullPath).replace(/\\/g, '/')
+
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue
+      await walkForPlanningArtifacts(root, fullPath, depth + 1, found)
+      continue
+    }
+
+    if (!entry.isFile()) continue
+    if (!PLANNING_FILE_NAMES.has(entry.name)) continue
+    found.add(relPath)
+  }
+}
+
+async function collectGitSnapshot(
+  cwd: string,
+): Promise<WorkspaceSnapshotGit | undefined> {
+  const isRepoResult = await execFileNoThrowWithCwd(
+    'git',
+    ['rev-parse', '--is-inside-work-tree'],
+    { cwd, timeout: 5000 },
+  )
+  if (isRepoResult.code !== 0 || isRepoResult.stdout.trim() !== 'true') {
+    return undefined
+  }
+
+  const [branchResult, headResult, statusResult, commitsResult] =
+    await Promise.all([
+      execFileNoThrowWithCwd('git', ['branch', '--show-current'], {
+        cwd,
+        timeout: 5000,
+      }),
+      execFileNoThrowWithCwd('git', ['rev-parse', '--short', 'HEAD'], {
+        cwd,
+        timeout: 5000,
+      }),
+      execFileNoThrowWithCwd(
+        'git',
+        ['status', '--short', '--untracked-files=normal'],
+        {
+          cwd,
+          timeout: 5000,
+        },
+      ),
+      execFileNoThrowWithCwd('git', ['log', '--oneline', '-n', `${GIT_COMMITS_LIMIT}`], {
+        cwd,
+        timeout: 5000,
+      }),
+    ])
+
+  return {
+    isRepo: true,
+    branch: branchResult.stdout.trim() || undefined,
+    head: headResult.stdout.trim() || undefined,
+    changedFiles: statusResult.stdout
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+      .slice(0, GIT_STATUS_LIMIT),
+    recentCommits: commitsResult.stdout
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+      .slice(0, GIT_COMMITS_LIMIT),
+  }
+}
+
+function formatBulletList(items: string[]): string[] {
+  if (!items.length) return ['- (none)']
+  return items.map(item => `- ${item}`)
+}

--- a/tests/soruxWrapper.test.ts
+++ b/tests/soruxWrapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  renderSoruxWrapper,
+  updateSoruxWrapperContent,
+} from '../src/utils/soruxWrapper.js'
+
+describe('renderSoruxWrapper', () => {
+  test('uses absolute binary paths and preserves caller cwd', () => {
+    const wrapper = renderSoruxWrapper('F:\\freecode\\free-code')
+    expect(wrapper).toContain('set "FREECODE_ROOT=F:\\freecode\\free-code"')
+    expect(wrapper).not.toContain('cd /d "%FREECODE_ROOT%"')
+    expect(wrapper).toContain('if exist "%FREECODE_ROOT%\\cli.exe"')
+    expect(wrapper).toContain('"%FREECODE_ROOT%\\cli.exe" %*')
+  })
+})
+
+describe('updateSoruxWrapperContent', () => {
+  test('updates repo root and removes forced cd while preserving auth env', () => {
+    const existing = `@echo off
+setlocal
+
+set "FREECODE_ROOT=F:\\old"
+set "OPENAI_API_KEY=abc"
+set "OPENAI_BASE_URL=https://example.com"
+
+cd /d "%FREECODE_ROOT%"
+
+if exist ".\\cli.exe" (
+  ".\\cli.exe" --model gpt-5.3-codex %*
+  exit /b %errorlevel%
+) else if exist ".\\cli-dev.exe" (
+  ".\\cli-dev.exe" --model gpt-5.3-codex %*
+  exit /b %errorlevel%
+)
+`
+
+    const updated = updateSoruxWrapperContent(
+      existing,
+      'F:\\freecode\\free-code',
+    )
+
+    expect(updated).toContain('set "FREECODE_ROOT=F:\\freecode\\free-code"')
+    expect(updated).toContain('set "OPENAI_API_KEY=abc"')
+    expect(updated).not.toContain('cd /d "%FREECODE_ROOT%"')
+    expect(updated).toContain('if exist "%FREECODE_ROOT%\\cli.exe"')
+    expect(updated).toContain('"%FREECODE_ROOT%\\cli-dev.exe" --model gpt-5.3-codex %*')
+  })
+})

--- a/tests/ultraplan/artifactPreview.test.ts
+++ b/tests/ultraplan/artifactPreview.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 
 import {
+  buildUltraplanArtifactMessage,
   formatUltraplanArtifactPreview,
   listUltraplanArtifacts,
   readUltraplanArtifact,
@@ -54,5 +55,18 @@ describe('formatUltraplanArtifactPreview', () => {
     const preview = formatUltraplanArtifactPreview('plan', long, 120)
     expect(preview.length).toBeLessThanOrEqual(150)
     expect(preview).toContain('(truncated)')
+  })
+})
+
+describe('buildUltraplanArtifactMessage', () => {
+  test('wraps artifact content for session reinsertion', () => {
+    const message = buildUltraplanArtifactMessage(
+      'stdout',
+      'C:/runs/demo',
+      'done',
+    )
+    expect(message).toContain('Ultraplan artifact: Planner stdout')
+    expect(message).toContain('C:/runs/demo')
+    expect(message).toContain('done')
   })
 })

--- a/tests/ultraplan/artifactPreview.test.ts
+++ b/tests/ultraplan/artifactPreview.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  formatUltraplanArtifactPreview,
+  listUltraplanArtifacts,
+  readUltraplanArtifact,
+} from '../../src/utils/ultraplan/artifactPreview.js'
+
+const tempRoots: string[] = []
+
+afterAll(async () => {
+  await Promise.all(
+    tempRoots.map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+async function makeRunDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'freecode-ultraplan-artifacts-'))
+  tempRoots.push(dir)
+  return dir
+}
+
+describe('listUltraplanArtifacts', () => {
+  test('returns the expected ordered artifact descriptors', () => {
+    const artifacts = listUltraplanArtifacts('C:/runs/demo')
+    expect(artifacts.map(item => item.key)).toEqual([
+      'plan',
+      'workspaceSnapshot',
+      'stdout',
+      'stderr',
+    ])
+    expect(artifacts[0]?.path).toContain('plan.md')
+    expect(artifacts[1]?.label).toContain('Workspace snapshot')
+  })
+})
+
+describe('readUltraplanArtifact', () => {
+  test('reads artifact content and falls back cleanly when missing', async () => {
+    const runDir = await makeRunDir()
+    await writeFile(join(runDir, 'plan.md'), '# Plan\n', 'utf8')
+
+    expect(await readUltraplanArtifact(runDir, 'plan')).toBe('# Plan\n')
+    expect(await readUltraplanArtifact(runDir, 'stderr')).toBeNull()
+  })
+})
+
+describe('formatUltraplanArtifactPreview', () => {
+  test('returns readable empty-state text and truncates long artifacts', () => {
+    expect(formatUltraplanArtifactPreview('stderr', null)).toContain('No stderr')
+    const long = 'a'.repeat(4100)
+    const preview = formatUltraplanArtifactPreview('plan', long, 120)
+    expect(preview.length).toBeLessThanOrEqual(150)
+    expect(preview).toContain('(truncated)')
+  })
+})

--- a/tests/ultraplan/plannerPrompt.test.ts
+++ b/tests/ultraplan/plannerPrompt.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  buildUltraplanSystemPrompt,
+  buildUltraplanUserPrompt,
+} from '../../src/utils/ultraplan/plannerPrompt.js'
+
+describe('buildUltraplanSystemPrompt', () => {
+  test('uses draft output contract when no seed plan is present', () => {
+    const prompt = buildUltraplanSystemPrompt('deep', false)
+    expect(prompt).toContain('1. Goal')
+    expect(prompt).toContain('3. Current Codebase Findings')
+    expect(prompt).toContain('8. Step-by-step Execution Plan')
+    expect(prompt).not.toContain('Keep')
+    expect(prompt).not.toContain('Revised Execution Plan')
+  })
+
+  test('uses refine output contract when a seed plan is present', () => {
+    const prompt = buildUltraplanSystemPrompt('max', true)
+    expect(prompt).toContain('2. Existing Plan Assessment')
+    expect(prompt).toContain('3. Keep')
+    expect(prompt).toContain('4. Change')
+    expect(prompt).toContain('5. Add')
+    expect(prompt).toContain('6. Revised Execution Plan')
+  })
+})
+
+describe('buildUltraplanUserPrompt', () => {
+  test('asks for structured refinement when a seed plan exists', () => {
+    const prompt = buildUltraplanUserPrompt(
+      'Refine the release plan',
+      '# Local Workspace Snapshot\n',
+      'deep',
+      '1. Ship it',
+    )
+
+    expect(prompt).toContain('Existing draft plan to refine:')
+    expect(prompt).toContain('Start by critiquing the draft plan')
+    expect(prompt).toContain('Keep / Change / Add')
+    expect(prompt).toContain('1. Ship it')
+  })
+})

--- a/tests/ultraplan/profile.test.ts
+++ b/tests/ultraplan/profile.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  getUltraplanProfileConfig,
+  parseUltraplanArgs,
+} from '../../src/utils/ultraplan/profile.js'
+
+describe('parseUltraplanArgs', () => {
+  test('defaults to deep when no profile flag is present', () => {
+    expect(parseUltraplanArgs('ship the feature')).toEqual({
+      blurb: 'ship the feature',
+      profile: 'deep',
+    })
+  })
+
+  test('supports short profile flags', () => {
+    expect(parseUltraplanArgs('--max fix auth flow')).toEqual({
+      blurb: 'fix auth flow',
+      profile: 'max',
+    })
+    expect(parseUltraplanArgs('--fast trim scope')).toEqual({
+      blurb: 'trim scope',
+      profile: 'fast',
+    })
+  })
+
+  test('supports explicit profile assignment forms', () => {
+    expect(parseUltraplanArgs('--profile=max polish release')).toEqual({
+      blurb: 'polish release',
+      profile: 'max',
+    })
+    expect(parseUltraplanArgs('--depth fast plan CI')).toEqual({
+      blurb: 'plan CI',
+      profile: 'fast',
+    })
+  })
+})
+
+describe('getUltraplanProfileConfig', () => {
+  test('returns distinct turn budgets by profile', () => {
+    expect(getUltraplanProfileConfig('fast').maxTurns).toBe(4)
+    expect(getUltraplanProfileConfig('deep').maxTurns).toBe(8)
+    expect(getUltraplanProfileConfig('max').maxTurns).toBe(14)
+  })
+})

--- a/tests/ultraplan/workspaceSnapshot.test.ts
+++ b/tests/ultraplan/workspaceSnapshot.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  buildWorkspaceSnapshotMarkdown,
+  collectWorkspaceSnapshot,
+} from '../../src/utils/ultraplan/workspaceSnapshot.js'
+
+const tempRoots: string[] = []
+
+afterAll(async () => {
+  await Promise.all(
+    tempRoots.map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+async function makeTempWorkspace(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'freecode-ultraplan-'))
+  tempRoots.push(dir)
+  return dir
+}
+
+async function run(
+  cwd: string,
+  ...cmd: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(cmd, {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+describe('collectWorkspaceSnapshot', () => {
+  test('captures git, manifests, top-level entries, and planning clues', async () => {
+    const cwd = await makeTempWorkspace()
+    await mkdir(join(cwd, 'src'))
+    await mkdir(join(cwd, 'docs'))
+    await writeFile(
+      join(cwd, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'snapshot-fixture',
+          packageManager: 'bun@1.3.11',
+          scripts: { build: 'bun run build.ts', test: 'bun test' },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+    await writeFile(join(cwd, 'bunfig.toml'), '[install]\ncache = true\n', 'utf8')
+    await writeFile(join(cwd, 'README.md'), '# Fixture\n', 'utf8')
+    await writeFile(
+      join(cwd, 'docs', 'IMPLEMENTATION_PLAN.md'),
+      '# Plan\n',
+      'utf8',
+    )
+    await writeFile(join(cwd, 'src', 'index.ts'), 'export const value = 1\n', 'utf8')
+
+    expect((await run(cwd, 'git', 'init')).exitCode).toBe(0)
+    expect(
+      (await run(cwd, 'git', 'config', 'user.email', 'fixture@example.com'))
+        .exitCode,
+    ).toBe(0)
+    expect(
+      (await run(cwd, 'git', 'config', 'user.name', 'Fixture User')).exitCode,
+    ).toBe(0)
+    expect((await run(cwd, 'git', 'add', '.')).exitCode).toBe(0)
+    expect((await run(cwd, 'git', 'commit', '-m', 'initial snapshot')).exitCode).toBe(
+      0,
+    )
+
+    await writeFile(join(cwd, 'README.md'), '# Fixture\n\nchanged\n', 'utf8')
+
+    const snapshot = await collectWorkspaceSnapshot(cwd)
+    const markdown = buildWorkspaceSnapshotMarkdown(snapshot)
+
+    expect(snapshot.cwd).toBe(cwd)
+    expect(snapshot.topLevel.directories).toContain('docs')
+    expect(snapshot.topLevel.directories).toContain('src')
+    expect(snapshot.topLevel.files).toContain('package.json')
+    expect(snapshot.manifests.some(item => item.path === 'package.json')).toBeTrue()
+    expect(snapshot.planningArtifacts).toContain('docs/IMPLEMENTATION_PLAN.md')
+    expect(snapshot.git?.isRepo).toBeTrue()
+    expect(snapshot.git?.changedFiles.join('\n')).toContain('README.md')
+    expect(snapshot.git?.recentCommits[0]).toContain('initial snapshot')
+    expect(markdown).toContain('snapshot-fixture')
+    expect(markdown).toContain('docs/IMPLEMENTATION_PLAN.md')
+    expect(markdown).toContain('README.md')
+  })
+})


### PR DESCRIPTION
﻿## Summary
This PR brings the local `/buddy` and `/ultraplan` capability gap fixes on top of `free-code`, based on a direct comparison against `Enchograph/whu-code`.

The comparison showed that `whu-code` also contains a large set of branding and i18n commits that are not part of this change. This PR intentionally keeps the scope narrow and only carries the buddy / ultraplan / Sorux-related deltas that are needed to restore the missing local workflows.

## User Impact
Before this change:
- `BUDDY` could be enabled, but the command surface was incomplete and the build path expected modules that were not fully wired.
- `/ultraplan` still reflected the remote-first flow, which did not match the local-only expectation for this fork.
- local planning output was harder to inspect and reuse once a planning run completed.

After this change:
- `/buddy` is available as a local command surface with status display and interaction hooks.
- `/ultraplan` launches a local planner flow in a new terminal instead of depending on the remote CCR-style path.
- completed planning artifacts can be previewed and reinserted back into the current session.
- Sorux wrapper updates preserve the caller working directory for local launch flows.

## Root Cause
This fork had already diverged from upstream `free-code`, but the local companion and planning workflows were only partially wired. In practice that left the repository with feature flags, UI affordances, and expectations for `/buddy` and `/ultraplan`, while key local execution pieces were still missing or still shaped around the remote implementation.

## Fix
The patch set is intentionally scoped to the local workflow path:
- add the `/buddy` command entrypoint and local companion card / observer behavior
- extend companion state handling so buddy interactions can be surfaced consistently in the REPL
- replace the old remote-oriented `/ultraplan` flow with a local terminal orchestration path
- add ultraplan profiles, planner prompt generation, artifact storage, artifact preview, and workspace snapshot capture
- wire the choice dialog and prompt input notices to the new local ultraplan lifecycle
- update Sorux launch handling so local planner launches preserve the active working directory
- add focused tests for Sorux wrapper behavior and the new ultraplan helpers

## Verification
Verified in a clean git worktree created from `HEAD` for this PR branch:
- `bun install`
- `bun test`
- `bun run build`

Results:
- `bun test`: 14 passed, 0 failed
- `bun run build`: succeeded and built `./cli`
