### PR TITLE
fix: Remove --bytecode flag to fix Mach-O signing corruption on M4

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -170,7 +170,6 @@ const cmd = [
   '--outfile',
   outfile,
   '--minify',
-  '--bytecode',
   '--packages',
   'bundle',
   '--conditions',


### PR DESCRIPTION
## Summary

Remove `--bytecode` from `scripts/build.ts` to fix **Mach-O binary corruption** 
on Apple Silicon (M4). The bytecode flag produces structurally corrupted binary 
headers, causing macOS Gatekeeper to **SIGKILL** the process immediately.

## Root Cause

`bun build --compile --bytecode` injects bytecode alongside the native Mach-O 
binary. On modern Apple Silicon, this bytecode overlay corrupts the code-signing 
layout enforced by the macOS kernel. Gatekeeper rejects the malformed signature 
and kills the process — hence the `zsh: killed` crash.

## Fix

Removing `--bytecode` restores standard binary format compatibility. The binary 
still compiles and minifies correctly — bytecode is an optimization layer 
unnecessary for clean Mach-O output.

## Test

- `file ./dist/cli` → `Mach-O 64-bit executable arm64`
- `codesign --force --deep -s - ./dist/cli` → succeeds (previously `invalid or unsupported format`)
- `./dist/cli /login` → no SIGKILL

## Related

Closes #29

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>