### PR TITLE
fix: prevent duplicate tool results on provider disconnect/fallback

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -124,13 +124,25 @@ function* yieldMissingToolResultBlocks(
   assistantMessages: AssistantMessage[],
   errorMessage: string,
 ) {
-  for (const assistantMessage of assistantMessages) {
+  // Filter out duplicate tool use blocks within the same message to prevent duplicate tool results
+  const uniqueAssistantMessages = assistantMessages.map(assistantMessage => {
+    const content = assistantMessage.message.content
+    const uniqueContent = content.filter((item, index, self) => {
+      if (item.type !== 'tool_use') return true
+      return index === self.findIndex(other =>
+        other.type === 'tool_use' && other.id === item.id
+      )
+    })
+    return { ...assistantMessage, message: { ...assistantMessage.message, content: uniqueContent } }
+  })
+
+  for (const assistantMessage of uniqueAssistantMessages) {
     // Extract all tool use blocks from this assistant message
     const toolUseBlocks = assistantMessage.message.content.filter(
       content => content.type === 'tool_use',
     ) as ToolUseBlock[]
 
-    // Emit an interruption message for each tool use
+    // Emit an interruption message for each unique tool use
     for (const toolUse of toolUseBlocks) {
       yield createUserMessage({
         content: [

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -74,6 +74,12 @@ export class StreamingToolExecutor {
    * Add a tool to the execution queue. Will start executing immediately if conditions allow.
    */
   addTool(block: ToolUseBlock, assistantMessage: AssistantMessage): void {
+    // Prevent duplicate tool additions - if a tool with this ID already exists, skip it.
+    // This can happen when provider disconnects/reconnects and resends the same tool_use block.
+    if (this.tools.some(t => t.id === block.id)) {
+      return
+    }
+
     const toolDefinition = findToolByName(this.toolDefinitions, block.name)
     if (!toolDefinition) {
       this.tools.push({


### PR DESCRIPTION
## Summary
Fixes duplicate `tool_result` submission when the provider reconnects mid-stream or when the model fallback pipeline re-processes an assistant message that already contains tool_use blocks.

Picks up work from closed-unmerged PR #42 (same fix, rebased onto current upstream `main` @ `6b25ab6`).

## Root cause
Two paths can emit a duplicate tool result for the same provider-issued `tool_use.id`:

1. **StreamingToolExecutor queue** — if the provider disconnects and reconnects, the SDK may re-send the same `tool_use` block. `addTool()` blindly queued it again → tool ran twice → two results.
2. **Fallback / interruption recovery** — `yieldMissingToolResultBlocks()` walks every assistant message and emits one result per `tool_use` block. If the same ID appears twice in the same message (reconnect artifact), it yields two results.

## Fix
Two minimal dedup guards, both keyed by `tool_use.id`:

- `src/services/tools/StreamingToolExecutor.ts` — `addTool` returns early if `block.id` is already in `this.tools`. This guarantees **at-most-once execution per ID**.
- `src/query.ts` — `yieldMissingToolResultBlocks` filters `content` so each `tool_use` ID is walked at most once. This guarantees **at-most-once result per ID** even in the fallback path.

Together they implement the *"treat a completed provider-issued tool-call ID as committed"* invariant from #38.

## Test plan
- [ ] Run Docker reproducer from issue #37: https://gist.github.com/N0zoM1z0/adb097dd6be467aa0cc1608d0e1dca6b — expect no `REPRODUCED`
- [ ] Run Docker reproducer from issue #38: https://gist.github.com/N0zoM1z0/1c2db900f5aef155cc647458cb7ba6d2 — expect no `REPRODUCED`
- [ ] Smoke-test normal multi-tool run still completes

I have not run the reproducers in this PR — they're self-contained Python+Docker and need a Linux host. Reviewer to verify.

Fixes #37
Fixes #38